### PR TITLE
Avoid simplexml_load_file warning when config path is a directory

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -170,14 +170,30 @@ class Options
     protected function getConfigurationPath($filtered)
     {
         if(isset($filtered['configuration']))
+            return $this->getDefaultConfigurationForPath($filtered['configuration'], $filtered['configuration']);
 
-            return file_exists($filtered['configuration']) ? realpath($filtered['configuration']) : $filtered['configuration'];
-        if(file_exists('phpunit.xml'))
+        return $this->getDefaultConfigurationForPath();
+    }
 
-            return realpath('phpunit.xml');
-        if(file_exists('phpunit.xml.dist'))
+    /**
+     * Retrieve the default configuration given a path (directory or file).
+     * This will search into the directory, if a directory is specified
+     *
+     * @param string $path The path to search into
+     * @param string $default The default value to give back
+     * @return string|null
+     */
+    private function getDefaultConfigurationForPath($path = '', $default = null)
+    {
+        $directory_separator = strlen($path) ? DIRECTORY_SEPARATOR : '';
+        $suffixes = array('', $directory_separator . 'phpunit.xml', $directory_separator . 'phpunit.xml.dist');
 
-            return realpath('phpunit.xml.dist');
+        foreach ($suffixes as $suffix) {
+            if (file_exists($path.$suffix) && !is_dir($path.$suffix))
+                return realpath($path.$suffix);
+        }
+
+        return $default;
     }
 
     /**

--- a/test/ParaTest/Runners/PHPUnit/OptionsTest.php
+++ b/test/ParaTest/Runners/PHPUnit/OptionsTest.php
@@ -14,7 +14,7 @@ class OptionsTest extends \TestBase
             'functional' => true,
             'group' => 'group1',
             'bootstrap' => '/path/to/bootstrap'
-        ); 
+        );
         $this->options = new Options($this->unfiltered);
         $this->cleanUpConfigurations();
     }
@@ -54,10 +54,28 @@ class OptionsTest extends \TestBase
         $this->assertEquals(__DIR__ . DS . 'phpunit.xml', $options->filtered['configuration']->getPath());
     }
 
+    public function testConfigurationShouldReturnXmlIfConfigSpecifiedAsDirectoryAndFileExists()
+    {
+        file_put_contents('phpunit.xml', '<root />');
+        $this->unfiltered['path'] = getcwd();
+        $this->unfiltered['configuration'] = getcwd();
+        $options = new Options($this->unfiltered);
+        $this->assertEquals(__DIR__ . DS . 'phpunit.xml', $options->filtered['configuration']->getPath());
+    }
+
     public function testConfigurationShouldReturnXmlDistIfConfigAndXmlNotSpecifiedAndFileExistsInCwd()
     {
         file_put_contents('phpunit.xml.dist', '<root />');
         $this->unfiltered['path'] = getcwd();
+        $options = new Options($this->unfiltered);
+        $this->assertEquals(__DIR__ . DS . 'phpunit.xml.dist', $options->filtered['configuration']->getPath());
+    }
+
+    public function testConfigurationShouldReturnXmlDistIfConfigSpecifiedAsDirectoryAndFileExists()
+    {
+        file_put_contents('phpunit.xml.dist', '<root />');
+        $this->unfiltered['path'] = getcwd();
+        $this->unfiltered['configuration'] = getcwd();
         $options = new Options($this->unfiltered);
         $this->assertEquals(__DIR__ . DS . 'phpunit.xml.dist', $options->filtered['configuration']->getPath());
     }


### PR DESCRIPTION
When using a directory for phpunit configuration path, with WARNING display enabled, it creates a multiple warnings on console output, thus messing report up.

I just added a new test to check if file is a directory, and if so then do not call the simple_load_file function on the directory.