### PR TITLE
[Bugfix: windows] Allow paratest to work even when paths contain spaces

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/ExecutableTest.php
+++ b/src/ParaTest/Runners/PHPUnit/ExecutableTest.php
@@ -179,8 +179,8 @@ abstract class ExecutableTest
     {
         // TODO: this should use a CommandBuilder
         $command = $binary;
-        foreach($options as $key => $value) $command .= " --$key %s";
-        $args = array_merge(array("$command %s %s"), array_values($options), array($this->fullyQualifiedClassName, $this->getPath()));
+        foreach($options as $key => $value) $command .= " --$key \"%s\"";
+        $args = array_merge(array("$command %s \"%s\""), array_values($options), array($this->fullyQualifiedClassName, $this->getPath()));
         $command = call_user_func_array('sprintf', $args);
         return $command;
     }

--- a/test/ParaTest/Runners/PHPUnit/ExecutableTestTest.php
+++ b/test/ParaTest/Runners/PHPUnit/ExecutableTestTest.php
@@ -26,7 +26,7 @@ class ExecutableTestTest extends \TestBase
         $binary = '/usr/bin/phpunit';
 
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options);
-        $this->assertEquals('/usr/bin/phpunit --bootstrap test/bootstrap.php ClassNameTest pathToFile', $command);
+        $this->assertEquals('/usr/bin/phpunit --bootstrap "test/bootstrap.php" ClassNameTest "pathToFile"', $command);
     }
 
     public function testCommandRedirectsCoverage()
@@ -36,7 +36,7 @@ class ExecutableTestTest extends \TestBase
 
         $command = $this->executableTestChild->command($binary, $options);
         $coverageFileName = str_replace('/', '\/', $this->executableTestChild->getCoverageFileName());
-        $this->assertRegExp('/^\/usr\/bin\/phpunit --a b --coverage-php ' . $coverageFileName . ' .*/', $command);
+        $this->assertRegExp('/^\/usr\/bin\/phpunit --a "b" --coverage-php "' . $coverageFileName . '" .*/', $command);
     }
 
     public function testGetCommandStringDoesNotIncludeEnvironmentVariablesToKeepCompatibilityWithWindows()
@@ -46,7 +46,7 @@ class ExecutableTestTest extends \TestBase
         $environmentVariables = array('APPLICATION_ENVIRONMENT_VAR' => 'abc');
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options, $environmentVariables);
 
-        $this->assertEquals('/usr/bin/phpunit --bootstrap test/bootstrap.php ClassNameTest pathToFile', $command);
+        $this->assertEquals('/usr/bin/phpunit --bootstrap "test/bootstrap.php" ClassNameTest "pathToFile"', $command);
     }
 
     public function testGetCommandStringIncludesTheClassName()
@@ -55,7 +55,7 @@ class ExecutableTestTest extends \TestBase
         $binary = '/usr/bin/phpunit';
 
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options);
-        $this->assertEquals('/usr/bin/phpunit ClassNameTest pathToFile', $command);
+        $this->assertEquals('/usr/bin/phpunit ClassNameTest "pathToFile"', $command);
     }
 
     public function testHandleEnvironmentVariablesAssignsToken()


### PR DESCRIPTION
Hello,

When attempting to run paratest on windows I was repeatedly getting `"Log file XYZ is empty. This means a PHPUnit process has crashed.`. After a bit of debugging it turns out this was due to phpunit being passed options (such as paths) that contained spaces.

I've added a fix that effectively just encases the option values in quotes in order to resolve this issue. Everything appears to be working normally for me now so i thought I may I may as well put in a pull with the fix.

Thanks,
Carl
