### PR TITLE
Error message when empty

### DIFF
--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -72,6 +72,17 @@ class Reader extends MetaProvider
     }
 
     /**
+     * Checks whether the xml log has
+     * test suite results
+     *
+     * @return array
+     */
+    public function hasResults()
+    {
+        return $this->xml->count() > 0;
+    }
+
+    /**
      * Return an array that contains
      * each suite's instant feedback. Since
      * logs do not contain skipped or incomplete
@@ -195,4 +206,5 @@ class Reader extends MetaProvider
             $this->suites[] = TestSuite::suiteFromNode($node);
         }
     }
+
 }

--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -206,5 +206,4 @@ class Reader extends MetaProvider
             $this->suites[] = TestSuite::suiteFromNode($node);
         }
     }
-
 }

--- a/src/ParaTest/Parser/ParsedClass.php
+++ b/src/ParaTest/Parser/ParsedClass.php
@@ -32,9 +32,15 @@ class ParsedClass extends ParsedObject
      */
     public function getMethods($annotations = array())
     {
-        $methods = array_filter($this->methods, function($m) use($annotations){
-            foreach($annotations as $a => $v)
-                return $m->hasAnnotation($a, $v);
+        $methods = array_filter($this->methods, function ($m) use ($annotations) {
+            foreach ($annotations as $a => $v) {
+                foreach (explode(',', $v) as $subValue) {
+                    if ($m->hasAnnotation($a, $subValue)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         });
         return $methods ? $methods : $this->methods;
     }

--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -162,6 +162,11 @@ class ResultPrinter
     public function printFeedback(ExecutableTest $test)
     {
         $reader = new Reader($test->getTempFile());
+        if (!$reader->hasResults()) {
+            throw new \RuntimeException("Log file " . $test->getTempFile() . " is empty.
+                This means a PHPUnit process was unable to run " . $test->getPath() . "
+                Maybe there is more than one class in this file.");
+        }
         $this->results->addReader($reader);
         $feedbackItems = $reader->getFeedback();
         foreach ($feedbackItems as $item)

--- a/test/fixtures/results/empty-test-suite.xml
+++ b/test/fixtures/results/empty-test-suite.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites/>

--- a/test/unit/ParaTest/Parser/ParsedClassTest.php
+++ b/test/unit/ParaTest/Parser/ParsedClassTest.php
@@ -9,16 +9,16 @@ class ParsedClassTest extends \TestBase
     {
         $this->methods = array(
             new ParsedFunction(
-            "/**
+                "/**
               * @group group1
               */",
-             'public', 'testFunction'
+                'public', 'testFunction'
             ),
             new ParsedFunction(
-            "/**
+                "/**
               * @group group2
               */",
-             'public', 'testFunction2'
+                'public', 'testFunction2'
             ),
             new ParsedFunction('', 'public', 'testFunction3')
         );
@@ -28,6 +28,31 @@ class ParsedClassTest extends \TestBase
     public function testGetMethodsReturnsMethods()
     {
         $this->assertEquals($this->methods, $this->class->getMethods());
+    }
+
+    public function testGetMethodsMultipleAnnotationsReturnsMethods()
+    {
+        $goodMethod = new ParsedFunction(
+            "/**
+              * @group group1
+              */",
+            'public', 'testFunction'
+        );
+        $goodMethod2 = new ParsedFunction(
+            "/**
+              * @group group2
+              */",
+            'public', 'testFunction2'
+        );
+        $badMethod = new ParsedFunction(
+            "/**
+              * @group group3
+              */",
+            'public', 'testFunction2'
+        );
+        $annotatedClass = new ParsedClass('', 'MyTestClass', '', array($goodMethod, $goodMethod2, $badMethod));
+        $methods = $annotatedClass->getMethods(array('group' => 'group1,group2'));
+        $this->assertEquals(array($goodMethod, $goodMethod2), $methods);
     }
 
     public function testGetMethodsExceptsAdditionalAnnotationFilter()

--- a/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
@@ -254,6 +254,16 @@ class ResultPrinterTest extends ResultTester
         $this->assertEquals($expected, $feedback);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testEmptyResultsLog(){
+        $suite = new Suite('/path/to/ResultSuite.php', array());
+        $empty = FIXTURES . DS . 'results' . DS . 'empty-test-suite.xml';
+        file_put_contents($suite->getTempFile(), file_get_contents($empty));
+        $this->printer->printFeedback($suite);
+    }
+
     protected function getStartOutput(Options $options)
     {
         ob_start();


### PR DESCRIPTION
The reason the previous pull request (https://github.com/brianium/paratest/pull/133) was failing is because when the tests are run with multiple, comma separated groups, the framework would pull all tests to execute. This leaves an empty log file, which is the symptom I was using to diagnose the issue.

The newest change updates the command to get test methods to iterate over comma separated values passed into the annotations.