### PR TITLE
Allow custom runners

### DIFF
--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -66,6 +66,17 @@ class PHPUnit extends Tester
         if ($input->getOption('runner') === 'WrapperRunner') {
             $runner = new WrapperRunner($this->getRunnerOptions($input));
         } else {
+            if ($input->getOption('runner') !== '') {
+                // because we want to have to bootstrap script inherited before check/initialization
+                $runnerOption = $this->getRunnerOptions($input);
+                $runnerClass = $input->getOption('runner');
+                if (class_exists($runnerClass)) {
+                    $runner = new $runnerClass($runnerOption);
+                }
+            }
+        }
+
+        if (!isset($runner)) {
             $runner = new Runner($this->getRunnerOptions($input));
         }
 

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -146,7 +146,7 @@ class Runner extends BaseRunner
      */
     protected function getNextAvailableToken()
     {
-        foreach($this->tokens as $token => $free) {
+        foreach ($this->tokens as $token => $free) {
             if ($free) {
                 return $token;
             }

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -134,7 +134,7 @@ class Runner extends BaseRunner
     {
         $this->tokens = array();
         for ($i=0; $i< $this->options->processes; $i++) {
-            $this->tokens[$i] = true;
+            $this->tokens[uniqid()] = true;
         }
     }
 
@@ -146,12 +146,11 @@ class Runner extends BaseRunner
      */
     protected function getNextAvailableToken()
     {
-        for ($i=0; $i< count($this->tokens); $i++) {
-            if ($this->tokens[$i]) {
-                return $i;
+        foreach($this->tokens as $token => $free) {
+            if ($free) {
+                return $token;
             }
         }
-
         return false;
     }
 

--- a/test/fixtures/paratest-only-tests/EnvironmentTest.php
+++ b/test/fixtures/paratest-only-tests/EnvironmentTest.php
@@ -12,8 +12,6 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
     public function testTestTokenVariableIsDefinedCorrectly()
     {
         $token = getenv('TEST_TOKEN');
-        $this->assertTrue(is_numeric($token));
-        $this->assertGreaterThanOrEqual(0, $token);
-        $this->assertLessThanOrEqual(5, $token);
+        $this->assertTrue(!empty($token));
     }
 }

--- a/test/functional/EmptyRunnerStub.php
+++ b/test/functional/EmptyRunnerStub.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * EmptyRunnerStub.php
+ *
+ * @package    Atlas
+ * @author     Christopher Biel <christopher.biel@jungheinrich.de>
+ * @copyright  2013 Jungheinrich AG
+ * @license    Proprietary license
+ * @version    $Id$
+ */
+class EmptyRunnerStub extends \ParaTest\Runners\PHPUnit\BaseRunner
+{
+    public function run()
+    {
+        echo "EXECUTED";
+    }
+}

--- a/test/functional/FunctionalTestBase.php
+++ b/test/functional/FunctionalTestBase.php
@@ -14,10 +14,10 @@ class FunctionalTestBase extends PHPUnit_Framework_TestCase
         return $fixture;
     }
 
-    protected function invokeParatest($path, $options = array())
+    protected function invokeParatest($path, $options = array(), $callback = null)
     {
         $invoker = new ParaTestInvoker($this->fixture($path), BOOTSTRAP);
-        return $invoker->execute($options);
+        return $invoker->execute($options, $callback);
     }
 
     protected function assertTestsPassed(Process $proc, $testPattern='\d+', $assertionPattern='\d+')

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -34,6 +34,21 @@ class PHPUnitTest extends FunctionalTestBase
         )));
     }
 
+    public function testWithCustomRunner()
+    {
+        $cb = new ProcessCallback();
+
+        $this->invokeParatest(
+            'passing-tests',
+            array(
+                'configuration' => PHPUNIT_CONFIGURATION,
+                'runner'        => 'EmptyRunnerStub'
+            ),
+            array($cb, 'callback')
+        );
+        $this->assertEquals('EXECUTED', $cb->getBuffer());
+    }
+
     public function testWithColorsGreenBar()
     {
         $proc = $this->invokeParatest('paratest-only-tests/EnvironmentTest.php',

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -17,14 +17,24 @@ class ParaTestInvoker
 
     /**
      * Runs the command, returns the proc after it's done
-     * @return \Symfony\Component\Process\Process
+     *
+     * @param array $options
+     * @param callable  $callback
+     *
+     * @return Process
      */
-    public function execute($options=array())
+    public function execute($options=array(), $callback = null)
     {
         $cmd = $this->buildCommand($options);
         $env = defined('PHP_WINDOWS_VERSION_BUILD') ? Habitat::getAll() : null;
         $proc = new Process($cmd, null, $env, null, $timeout = 600);
-        $proc->run();
+
+        if (!is_callable($callback)) {
+            $proc->run();
+        } else {
+            $proc->run($callback);
+        }
+
         return $proc;
     }
 

--- a/test/functional/ProcessCallback.php
+++ b/test/functional/ProcessCallback.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * ProcessCallback.php
+ *
+ * @package    Atlas
+ * @author     Christopher Biel <christopher.biel@jungheinrich.de>
+ * @copyright  2013 Jungheinrich AG
+ * @license    Proprietary license
+ * @version    $Id$
+ */
+class ProcessCallback
+{
+    protected $type;
+    protected $buffer;
+
+    public function callback($type, $buffer)
+    {
+        $this->type = $type;
+        $this->buffer = $buffer;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBuffer()
+    {
+        return $this->buffer;
+    }
+}


### PR DESCRIPTION
This pull requests allows the developer to use a custom runner that extends BaseRunner

For me this is a semi-workaround for the windows wrapperrunner problem, because I can provide my own runner with pre-post scripts per token. but i will have a closer look into the windows issues when there is time


also change the tokens from numeric to uniqueid's because that is more generic and you can e.g. do something like creating a prepared database for every token before running the actual test (this custom runner is not included)