### PR TITLE
Nested testsuites support

### DIFF
--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -66,6 +66,17 @@ class PHPUnit extends Tester
         if ($input->getOption('runner') === 'WrapperRunner') {
             $runner = new WrapperRunner($this->getRunnerOptions($input));
         } else {
+            if ($input->getOption('runner') !== '') {
+                // because we want to have to bootstrap script inherited before check/initialization
+                $runnerOption = $this->getRunnerOptions($input);
+                $runnerClass = $input->getOption('runner');
+                if (class_exists($runnerClass)) {
+                    $runner = new $runnerClass($runnerOption);
+                }
+            }
+        }
+
+        if (!isset($runner)) {
             $runner = new Runner($this->getRunnerOptions($input));
         }
 

--- a/src/ParaTest/Runners/PHPUnit/Configuration.php
+++ b/src/ParaTest/Runners/PHPUnit/Configuration.php
@@ -1,5 +1,6 @@
 <?php
 namespace ParaTest\Runners\PHPUnit;
+use ParaTest\Parser\Parser;
 
 /**
  * Class Configuration
@@ -22,6 +23,8 @@ class Configuration
      * @var \SimpleXMLElement
      */
     protected $xml;
+
+    protected $availableNodes = array('file', 'directory', 'testsuite');
 
     /**
      * A collection of datastructures
@@ -79,41 +82,47 @@ class Configuration
             return null;
         }
         $suites = array();
-        $nodes = $this->xml->xpath('//testsuite');
+        $nodes = $this->xml->xpath('//testsuites/testsuite');
+
         while (list(, $node) = each($nodes)) {
-            foreach ($node->directory as $dir) {
-                foreach ($this->getSuitePaths((string) $dir) as $path) {
-                    $suites[(string)$node['name']][] = new SuitePath($path, $dir->attributes()->suffix);
-                }
-            }
+            $suites = array_merge_recursive($suites, $this->getSuiteByName((string)$node['name']));
         }
         return $suites;
     }
 
-    public function getTestsuiteItems()
-    {
-
-    }
-
     /**
+     * Return the contents of the <testsuite> nodes
+     * contained in a PHPUnit configuration
+     *
      * @param string $suiteName
      *
-     * @return array|null
+     * @return array
      */
-    public function getSuiteFiles($suiteName)
+    public function getSuiteByName($suiteName)
     {
         $nodes = $this->xml->xpath(sprintf('//testsuite[@name="%s"]', $suiteName));
 
-        $files = array();
+        $suites = array();
         while (list(, $node) = each($nodes)) {
-            foreach ($node->file as $file) {
-                foreach ($this->getSuitePaths((string) $file) as $path) {
-                    $files[] = $path;
+            foreach ($this->availableNodes as $nodeName) {
+                foreach ($node->{$nodeName} as $nodeContent) {
+                    switch ($nodeName) {
+                        case 'testsuite':
+                            $suites = array_merge_recursive($suites, $this->getSuiteByName((string)$nodeContent));
+                            break;
+                        default:
+                            foreach ($this->getSuitePaths((string)$nodeContent) as $path) {
+                                $suites[(string)$node['name']][] = new SuitePath(
+                                    $path, $nodeContent->attributes()->suffix
+                                );
+                            }
+                            break;
+                    }
                 }
             }
         }
 
-        return $files;
+        return $suites;
     }
 
     /**

--- a/src/ParaTest/Runners/PHPUnit/Configuration.php
+++ b/src/ParaTest/Runners/PHPUnit/Configuration.php
@@ -1,6 +1,5 @@
 <?php
 namespace ParaTest\Runners\PHPUnit;
-use ParaTest\Parser\Parser;
 
 /**
  * Class Configuration
@@ -113,7 +112,8 @@ class Configuration
                         default:
                             foreach ($this->getSuitePaths((string)$nodeContent) as $path) {
                                 $suites[(string)$node['name']][] = new SuitePath(
-                                    $path, $nodeContent->attributes()->suffix
+                                    $path,
+                                    $nodeContent->attributes()->suffix
                                 );
                             }
                             break;

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -146,7 +146,7 @@ class Runner extends BaseRunner
      */
     protected function getNextAvailableToken()
     {
-        foreach($this->tokens as $token => $free) {
+        foreach ($this->tokens as $token => $free) {
             if ($free) {
                 return $token;
             }

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -134,7 +134,7 @@ class Runner extends BaseRunner
     {
         $this->tokens = array();
         for ($i=0; $i< $this->options->processes; $i++) {
-            $this->tokens[$i] = true;
+            $this->tokens[uniqid()] = true;
         }
     }
 
@@ -146,12 +146,11 @@ class Runner extends BaseRunner
      */
     protected function getNextAvailableToken()
     {
-        for ($i=0; $i< count($this->tokens); $i++) {
-            if ($this->tokens[$i]) {
-                return $i;
+        foreach($this->tokens as $token => $free) {
+            if ($free) {
+                return $token;
             }
         }
-
         return false;
     }
 

--- a/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
+++ b/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
@@ -93,15 +93,11 @@ class SuiteLoader
         if ($path) {
             $this->loadPath($path);
         } elseif (isset($this->options->testsuite) && $this->options->testsuite) {
-            foreach ($configuration->getSuiteFiles($this->options->testsuite) as $file) {
-                $this->loadFile($file);
-            }
-            foreach ($configuration->getSuites() as $suite) {
+            foreach ($configuration->getSuiteByName($this->options->testsuite) as $suite) {
                 foreach ($suite as $suitePath) {
                     $this->loadPath($suitePath);
                 }
             }
-            $this->files = array_unique($this->files); // remove duplicates
         } elseif ($suites = $configuration->getSuites()) {
             foreach ($suites as $suite) {
                 foreach ($suite as $suitePath) {
@@ -113,6 +109,8 @@ class SuiteLoader
         if (!$this->files) {
             throw new \RuntimeException("No path or configuration provided (tests must end with Test.php)");
         }
+
+        $this->files = array_unique($this->files); // remove duplicates
 
         $this->initSuites();
     }

--- a/test/fixtures/paratest-only-tests/EnvironmentTest.php
+++ b/test/fixtures/paratest-only-tests/EnvironmentTest.php
@@ -12,8 +12,6 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
     public function testTestTokenVariableIsDefinedCorrectly()
     {
         $token = getenv('TEST_TOKEN');
-        $this->assertTrue(is_numeric($token));
-        $this->assertGreaterThanOrEqual(0, $token);
-        $this->assertLessThanOrEqual(5, $token);
+        $this->assertTrue(!empty($token));
     }
 }

--- a/test/fixtures/phpunit-files-dirs-mix-nested.xml
+++ b/test/fixtures/phpunit-files-dirs-mix-nested.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="../bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+        >
+    <testsuites>
+        <testsuite name="ParaTest Fixtures">
+            <directory>./failing-tests/</directory>
+            <file>./passing-tests/TestOfUnits.php</file>
+            <file>./passing-tests/GroupsTest.php</file>
+            <testsuite>Nested Suite</testsuite>
+        </testsuite>
+        <testsuite name="Nested Suite">
+            <directory>./passing-tests/</directory>
+            <file>./passing-tests/GroupsTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/functional/EmptyRunnerStub.php
+++ b/test/functional/EmptyRunnerStub.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * EmptyRunnerStub.php
+ *
+ * @package    Atlas
+ * @author     Christopher Biel <christopher.biel@jungheinrich.de>
+ * @copyright  2013 Jungheinrich AG
+ * @license    Proprietary license
+ * @version    $Id$
+ */
+class EmptyRunnerStub extends \ParaTest\Runners\PHPUnit\BaseRunner
+{
+    public function run()
+    {
+        echo "EXECUTED";
+    }
+}

--- a/test/functional/FunctionalTestBase.php
+++ b/test/functional/FunctionalTestBase.php
@@ -14,10 +14,10 @@ class FunctionalTestBase extends PHPUnit_Framework_TestCase
         return $fixture;
     }
 
-    protected function invokeParatest($path, $options = array())
+    protected function invokeParatest($path, $options = array(), $callback = null)
     {
         $invoker = new ParaTestInvoker($this->fixture($path), BOOTSTRAP);
-        return $invoker->execute($options);
+        return $invoker->execute($options, $callback);
     }
 
     protected function assertTestsPassed(Process $proc, $testPattern='\d+', $assertionPattern='\d+')

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -34,6 +34,21 @@ class PHPUnitTest extends FunctionalTestBase
         )));
     }
 
+    public function testWithCustomRunner()
+    {
+        $cb = new ProcessCallback();
+
+        $this->invokeParatest(
+            'passing-tests',
+            array(
+                'configuration' => PHPUNIT_CONFIGURATION,
+                'runner'        => 'EmptyRunnerStub'
+            ),
+            array($cb, 'callback')
+        );
+        $this->assertEquals('EXECUTED', $cb->getBuffer());
+    }
+
     public function testWithColorsGreenBar()
     {
         $proc = $this->invokeParatest('paratest-only-tests/EnvironmentTest.php',

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -17,14 +17,24 @@ class ParaTestInvoker
 
     /**
      * Runs the command, returns the proc after it's done
-     * @return \Symfony\Component\Process\Process
+     *
+     * @param array $options
+     * @param callable  $callback
+     *
+     * @return Process
      */
-    public function execute($options=array())
+    public function execute($options=array(), $callback = null)
     {
         $cmd = $this->buildCommand($options);
         $env = defined('PHP_WINDOWS_VERSION_BUILD') ? Habitat::getAll() : null;
         $proc = new Process($cmd, null, $env, null, $timeout = 600);
-        $proc->run();
+
+        if (!is_callable($callback)) {
+            $proc->run();
+        } else {
+            $proc->run($callback);
+        }
+
         return $proc;
     }
 

--- a/test/functional/ProcessCallback.php
+++ b/test/functional/ProcessCallback.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * ProcessCallback.php
+ *
+ * @package    Atlas
+ * @author     Christopher Biel <christopher.biel@jungheinrich.de>
+ * @copyright  2013 Jungheinrich AG
+ * @license    Proprietary license
+ * @version    $Id$
+ */
+class ProcessCallback
+{
+    protected $type;
+    protected $buffer;
+
+    public function callback($type, $buffer)
+    {
+        $this->type = $type;
+        $this->buffer = $buffer;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBuffer()
+    {
+        return $this->buffer;
+    }
+}

--- a/test/unit/ParaTest/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/SuiteLoaderTest.php
@@ -93,12 +93,28 @@ class SuiteLoaderTest extends \TestBase
 
     public function testLoadTestsuiteWithFilesDirsMixed()
     {
-        $options = new Options(array('configuration' => $this->fixture('phpunit-files-dirs-mix.xml'), 'testsuite' => 'ParaTest Fixtures'));
+        $options = new Options(
+            array('configuration' => $this->fixture('phpunit-files-dirs-mix.xml'), 'testsuite' => 'ParaTest Fixtures')
+        );
         $loader = new SuiteLoader($options);
         $loader->load();
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = sizeof($this->findTests(FIXTURES . DS . 'failing-tests')) + 2;
+        $this->assertEquals($expected, sizeof($files));
+    }
+
+    public function testLoadTestsuiteWithNestedSuite()
+    {
+        $options = new Options(
+            array('configuration' => $this->fixture('phpunit-files-dirs-mix-nested.xml'), 'testsuite' => 'ParaTest Fixtures')
+        );
+        $loader = new SuiteLoader($options);
+        $loader->load();
+        $files = $this->getObjectValue($loader, 'files');
+
+        $expected = sizeof($this->findTests(FIXTURES . DS . 'passing-tests')) +
+            sizeof($this->findTests(FIXTURES . DS . 'failing-tests')) + 1;
         $this->assertEquals($expected, sizeof($files));
     }
 


### PR DESCRIPTION
For better structure in phpunit.xml I added the possibility to use nested <testsuite> elements.

for example this is helpful in such a case:

```xml
<testsuites>
    <testsuite name="feature 1">
        <directory>some-dir</directory>
    </testsuite>
    <testsuite name="feature 2">
        <file>feature2-1Test.php</file>
        <file>feature2-2Test.php</file>
    </testsuite>
    <testsuite name="all">
        <testsuite>feature 1</testsuite>
        <testsuite>feature 2</testsuite>
    </testsuite>
</testsuites>
```

in this case paratest now would fetch all testfiles from feature 1 + 2 when executing.

paratest --testsuite=all

the implementation is recursive so n-level nesting should be possible.

I will also schedule a pull request for phpunit to support this (but this take some more time...^^)