### PR TITLE
Merged #65: Avoid simplexml_load_file warning when config path is a directory

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -192,19 +192,28 @@ class Options
      */
     protected function getConfigurationPath($filtered)
     {
-        if (isset($filtered['configuration'])) {
-            return file_exists($filtered['configuration'])
-                ? realpath($filtered['configuration'])
-                : $filtered['configuration'];
-        }
+        if(isset($filtered['configuration']))
+            return $this->getDefaultConfigurationForPath($filtered['configuration'], $filtered['configuration']);
+        return $this->getDefaultConfigurationForPath();
+    }
 
-        if (file_exists('phpunit.xml')) {
-            return realpath('phpunit.xml');
+    /**
+     * Retrieve the default configuration given a path (directory or file).
+     * This will search into the directory, if a directory is specified
+     *
+     * @param string $path The path to search into
+     * @param string $default The default value to give back
+     * @return string|null
+     */
+    private function getDefaultConfigurationForPath($path = '', $default = null)
+    {
+        $directory_separator = strlen($path) ? DIRECTORY_SEPARATOR : '';
+        $suffixes = array('', $directory_separator . 'phpunit.xml', $directory_separator . 'phpunit.xml.dist');
+        foreach ($suffixes as $suffix) {
+            if (file_exists($path.$suffix) && !is_dir($path.$suffix))
+                return realpath($path.$suffix);
         }
-
-        if (file_exists('phpunit.xml.dist')) {
-            return realpath('phpunit.xml.dist');
-        }
+        return $default;
     }
 
     /**

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -192,8 +192,9 @@ class Options
      */
     protected function getConfigurationPath($filtered)
     {
-        if(isset($filtered['configuration']))
+        if (isset($filtered['configuration'])) {
             return $this->getDefaultConfigurationForPath($filtered['configuration'], $filtered['configuration']);
+        }
         return $this->getDefaultConfigurationForPath();
     }
 
@@ -210,8 +211,9 @@ class Options
         $directory_separator = strlen($path) ? DIRECTORY_SEPARATOR : '';
         $suffixes = array('', $directory_separator . 'phpunit.xml', $directory_separator . 'phpunit.xml.dist');
         foreach ($suffixes as $suffix) {
-            if (file_exists($path.$suffix) && !is_dir($path.$suffix))
-                return realpath($path.$suffix);
+            if (file_exists($path.$suffix) && !is_dir($path.$suffix)) {
+                return realpath($path . $suffix);
+            }
         }
         return $default;
     }

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -206,12 +206,17 @@ class Options
      * @param string $default The default value to give back
      * @return string|null
      */
-    private function getDefaultConfigurationForPath($path = '', $default = null)
+    private function getDefaultConfigurationForPath($path = '.', $default = null)
     {
-        $directory_separator = strlen($path) ? DIRECTORY_SEPARATOR : '';
-        $suffixes = array('', $directory_separator . 'phpunit.xml', $directory_separator . 'phpunit.xml.dist');
+        if ($this->isFile($path)) {
+            return realpath($path);
+        }
+
+        $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $suffixes = array('phpunit.xml', 'phpunit.xml.dist');
+
         foreach ($suffixes as $suffix) {
-            if (file_exists($path.$suffix) && !is_dir($path.$suffix)) {
+            if ($this->isFile($path . $suffix)) {
                 return realpath($path . $suffix);
             }
         }
@@ -230,5 +235,14 @@ class Options
                 $this->annotations[$key] = $value;
             }
         }
+    }
+
+    /**
+     * @param $file
+     * @return bool
+     */
+    private function isFile($file)
+    {
+        return file_exists($file) && !is_dir($file);
     }
 }

--- a/test/unit/ParaTest/Runners/PHPUnit/OptionsTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/OptionsTest.php
@@ -106,9 +106,6 @@ class OptionsTest extends \TestBase
             unlink('myconfig.xml');
     }
 
-    /**
-     * @group wip
-     */
     public function testConfigurationShouldReturnXmlIfConfigSpecifiedAsDirectoryAndFileExists()
     {
         file_put_contents('phpunit.xml', '<root />');
@@ -118,9 +115,6 @@ class OptionsTest extends \TestBase
         $this->assertEquals(__DIR__ . DS . 'phpunit.xml', $options->filtered['configuration']->getPath());
     }
 
-    /**
-     * @group wip
-     */
     public function testConfigurationShouldReturnXmlDistIfConfigSpecifiedAsDirectoryAndFileExists()
     {
         file_put_contents('phpunit.xml.dist', '<root />');

--- a/test/unit/ParaTest/Runners/PHPUnit/OptionsTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/OptionsTest.php
@@ -48,28 +48,17 @@ class OptionsTest extends \TestBase
 
     public function testConfigurationShouldReturnXmlIfConfigNotSpecifiedAndFileExistsInCwd()
     {
-        file_put_contents('phpunit.xml', '<root />');
-        $this->unfiltered['path'] = getcwd();
-        $options = new Options($this->unfiltered);
-        $this->assertEquals(__DIR__ . DS . 'phpunit.xml', $options->filtered['configuration']->getPath());
+        $this->assertConfigurationFileFiltered('phpunit.xml', getcwd());
     }
 
     public function testConfigurationShouldReturnXmlDistIfConfigAndXmlNotSpecifiedAndFileExistsInCwd()
     {
-        file_put_contents('phpunit.xml.dist', '<root />');
-        $this->unfiltered['path'] = getcwd();
-        $options = new Options($this->unfiltered);
-        $this->assertEquals(__DIR__ . DS . 'phpunit.xml.dist', $options->filtered['configuration']->getPath());
+        $this->assertConfigurationFileFiltered('phpunit.xml.dist', getcwd());
     }
 
     public function testConfigurationShouldReturnSpecifiedConfigurationIfFileExists()
     {
-        file_put_contents('myconfig.xml', '<root />');
-        $this->unfiltered['configuration'] = 'myconfig.xml';
-        $this->unfiltered['path'] = getcwd();
-        $options = new Options($this->unfiltered);
-
-        $this->assertEquals(__DIR__ . DS . 'myconfig.xml', $options->filtered['configuration']->getPath());
+        $this->assertConfigurationFileFiltered('myconfig.xml', getcwd(), 'myconfig.xml');
     }
 
     public function testConfigurationShouldBeSetEvenIfFileDoesNotExist()
@@ -108,19 +97,27 @@ class OptionsTest extends \TestBase
 
     public function testConfigurationShouldReturnXmlIfConfigSpecifiedAsDirectoryAndFileExists()
     {
-        file_put_contents('phpunit.xml', '<root />');
-        $this->unfiltered['path'] = getcwd();
-        $this->unfiltered['configuration'] = getcwd();
-        $options = new Options($this->unfiltered);
-        $this->assertEquals(__DIR__ . DS . 'phpunit.xml', $options->filtered['configuration']->getPath());
+        $this->assertConfigurationFileFiltered('phpunit.xml', getcwd(), getcwd());
     }
 
     public function testConfigurationShouldReturnXmlDistIfConfigSpecifiedAsDirectoryAndFileExists()
     {
-        file_put_contents('phpunit.xml.dist', '<root />');
-        $this->unfiltered['path'] = getcwd();
-        $this->unfiltered['configuration'] = getcwd();
+        $this->assertConfigurationFileFiltered('phpunit.xml.dist', getcwd(), getcwd());
+    }
+
+    /**
+     * @param $configFileName
+     * @param $path
+     * @param $configurationParameter
+     */
+    private function assertConfigurationFileFiltered($configFileName, $path, $configurationParameter = null)
+    {
+        file_put_contents($configFileName, '<root />');
+        $this->unfiltered['path'] = $path;
+        if ($configurationParameter !== null) {
+            $this->unfiltered['configuration'] = $configurationParameter;
+        }
         $options = new Options($this->unfiltered);
-        $this->assertEquals(__DIR__ . DS . 'phpunit.xml.dist', $options->filtered['configuration']->getPath());
+        $this->assertEquals(__DIR__ . DS . $configFileName, $options->filtered['configuration']->getPath());
     }
 }

--- a/test/unit/ParaTest/Runners/PHPUnit/OptionsTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/OptionsTest.php
@@ -105,4 +105,28 @@ class OptionsTest extends \TestBase
         if(file_exists('myconfig.xml'))
             unlink('myconfig.xml');
     }
+
+    /**
+     * @group wip
+     */
+    public function testConfigurationShouldReturnXmlIfConfigSpecifiedAsDirectoryAndFileExists()
+    {
+        file_put_contents('phpunit.xml', '<root />');
+        $this->unfiltered['path'] = getcwd();
+        $this->unfiltered['configuration'] = getcwd();
+        $options = new Options($this->unfiltered);
+        $this->assertEquals(__DIR__ . DS . 'phpunit.xml', $options->filtered['configuration']->getPath());
+    }
+
+    /**
+     * @group wip
+     */
+    public function testConfigurationShouldReturnXmlDistIfConfigSpecifiedAsDirectoryAndFileExists()
+    {
+        file_put_contents('phpunit.xml.dist', '<root />');
+        $this->unfiltered['path'] = getcwd();
+        $this->unfiltered['configuration'] = getcwd();
+        $options = new Options($this->unfiltered);
+        $this->assertEquals(__DIR__ . DS . 'phpunit.xml.dist', $options->filtered['configuration']->getPath());
+    }
 }

--- a/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
@@ -55,7 +55,7 @@ class ResultPrinterTest extends ResultTester
         $options = new Options();
         $contents = $this->getStartOutput($options);
         $expected = sprintf("\nRunning phpunit in 5 processes with %s\n\n", $options->phpunit);
-        $this->assertEquals($expected, $contents);
+        $this->assertStringStartsWith($expected, $contents);
     }
 
     public function testStartSetsWidthAndMaxColumn()
@@ -80,7 +80,7 @@ class ResultPrinterTest extends ResultTester
         $expected = sprintf("\nRunning phpunit in 5 processes with %s\n\nConfiguration read from %s\n\n",
                             $options->phpunit,
                             __DIR__ . DS . 'myconfig.xml');
-        $this->assertEquals($expected, $contents);
+        $this->assertStringStartsWith($expected, $contents);
     }
 
     public function testStartPrintsOptionInfoWithFunctionalMode()
@@ -88,7 +88,7 @@ class ResultPrinterTest extends ResultTester
         $options = new Options(array('functional' => true));
         $contents = $this->getStartOutput($options);
         $expected = sprintf("\nRunning phpunit in 5 processes with %s. Functional mode is on\n\n", $options->phpunit);
-        $this->assertEquals($expected, $contents);
+        $this->assertStringStartsWith($expected, $contents);
     }
 
     public function testStartPrintsOptionInfoWithSingularForOneProcess()
@@ -96,7 +96,7 @@ class ResultPrinterTest extends ResultTester
         $options = new Options(array('processes' => 1));
         $contents = $this->getStartOutput($options);
         $expected = sprintf("\nRunning phpunit in 1 process with %s\n\n", $options->phpunit);
-        $this->assertEquals($expected, $contents);
+        $this->assertStringStartsWith($expected, $contents);
     }
 
     public function testAddSuiteAddsFunctionCountToTotalTestCases()


### PR DESCRIPTION
This fixes #65  (is basically a merge of that old PR).
I don't know what the old discussion was about (what diffs that discussion was about) but to me, it looks well tested.
A directory is passed in as configuration an both, phpunit.xml or phpunit.xml.dist are loaded of they exist. The only thing that could be added is a test for the load order (phpunit.xml.dist only if phpunit.xml does not exist). But I don't know what exactly @giorgiosironi was complaining about back then.