### PR TITLE
uniqid() is not unique enough so add usleep to ensure uniqueness

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -30,6 +30,3 @@ tools:
       standard: "PSR2"
   
   php_code_coverage: true
-  
-build_failure_conditions:
-  - 'issues.new.exists'

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -134,8 +134,7 @@ class Runner extends BaseRunner
     {
         $this->tokens = array();
         for ($i = 0; $i < $this->options->processes; $i++) {
-            $this->tokens[$i] = array('token' => $i, 'unique' => uniqid(), 'available' => true);
-            usleep(1);
+            $this->tokens[$i] = array('token' => $i, 'unique' => uniqid($i), 'available' => true);
         }
     }
 

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -135,6 +135,7 @@ class Runner extends BaseRunner
         $this->tokens = array();
         for ($i = 0; $i < $this->options->processes; $i++) {
             $this->tokens[$i] = array('token' => $i, 'unique' => uniqid(), 'available' => true);
+            usleep(1);
         }
     }
 


### PR DESCRIPTION
When uniqid is executed to fast in a row the generated id's are unique. usleep ensures a uniqueid

would be 0.12.1 i think