### PR TITLE
Enhancement: Use SVG badge for displaying Travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ParaTest
 ========
 
-[![Build Status](https://secure.travis-ci.org/brianium/paratest.png?branch=master)](https://travis-ci.org/brianium/paratest)
+[![Build Status](https://travis-ci.org/brianium/paratest.svg?branch=master)](https://travis-ci.org/brianium/paratest)
 [![HHVM Status](http://hhvm.h4cc.de/badge/brianium/paratest.svg)](http://hhvm.h4cc.de/package/brianium/paratest)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/brianium/paratest/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/brianium/paratest/?branch=master)
 [![Packagist](https://img.shields.io/packagist/dt/brianium/paratest.svg)](https://packagist.org/packages/brianium/paratest)


### PR DESCRIPTION
This PR

* [x] uses an SVB badge for displaying the Travis build status, as it is more pleasing for the eye