### PR TITLE
Fix: Split autoloading into autoload and autoload-dev sections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,12 @@
     "bin": ["bin/paratest"],
     "autoload": {
         "psr-0": {
-            "": ["test/unit", "test/functional"],
             "ParaTest": ["src/"]
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "": ["test/unit", "test/functional"]
         }
     }
 }


### PR DESCRIPTION
This PR

* [x] splits Composer autoloading into `autoload` and `autoload-dev` sections