### PR TITLE
Fix: Remove hhvm-nightly from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,10 @@ php:
     - "5.5"
     - "5.4"
     - "5.3"
-    - hhvm-nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: hhvm-nightly
     - env: PHPUNIT_VERSION='4.*@dev'
 
 env:


### PR DESCRIPTION
This PR

* [x] removes `hhvm-nightly` from the build matrix

See https://travis-ci.org/brianium/paratest/jobs/68879258#L66:

> HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220

Related to #166.