### PR TITLE
Fix: Remove hhvm-nightly from Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
     - "5.5"
     - "5.4"
     - "5.3"
-    - hhvm-nightly
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This PR

* [x] removes `hhvm-nightly` from the build matrix

Related to #166.