### PR TITLE
avoid using simplexml_load_file for security reason

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/Configuration.php
+++ b/src/ParaTest/Runners/PHPUnit/Configuration.php
@@ -38,9 +38,7 @@ class Configuration
     {
         $this->path = $path;
         if (file_exists($path)) {
-            $before = libxml_disable_entity_loader(false);
-            $this->xml = simplexml_load_file($path);
-            libxml_disable_entity_loader($before);
+            $this->xml = simplexml_load_string(file_get_contents($path));
         }
     }
 


### PR DESCRIPTION
I've run into troubles trying to use paratest. For security reasons some hosters disable function simplexml_load_file, but our team went even further and just compiled php without it. So what do you think about this small change?