### PR TITLE
Adds more detailed message when printing feedback

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -189,7 +189,19 @@ class ResultPrinter
      */
     public function printFeedback(ExecutableTest $test)
     {
-        $reader = new Reader($test->getTempFile());
+        try {
+            $reader = new Reader($test->getTempFile());
+        } catch (\InvalidArgumentException $e) {
+            throw new \RuntimeException(sprintf(
+                "%s\n" .
+                "The process: %s\n" .
+                "This means a PHPUnit process was unable to run \"%s\"\n" .
+                "This is is a good starting point for debugging.\n",
+                $e->getmessage(),
+                $test->getLastCommand(),
+                $test->getPath()
+            ));
+        }
         if (!$reader->hasResults()) {
             throw new \RuntimeException(sprintf(
                 "The process: %s\nLog file \"%s\" is empty.\n" .

--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -195,8 +195,7 @@ class ResultPrinter
             throw new \RuntimeException(sprintf(
                 "%s\n" .
                 "The process: %s\n" .
-                "This means a PHPUnit process was unable to run \"%s\"\n" .
-                "This is is a good starting point for debugging.\n",
+                "This means a PHPUnit process was unable to run \"%s\"\n" ,
                 $e->getmessage(),
                 $test->getLastCommand(),
                 $test->getPath()


### PR DESCRIPTION
Adds more detailed message other then "This means a PHPUnit process has crashed" when printing feedback. With this information it's much easier to start debugging what file might have an error.