### PR TITLE
Fix workers crashing when we're on a filesystem path with spaces

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/Worker.php
+++ b/src/ParaTest/Runners/PHPUnit/Worker.php
@@ -32,7 +32,7 @@ class Worker
         if ($uniqueToken) {
             $bin .= "UNIQUE_TEST_TOKEN=$uniqueToken ";
         }
-        $bin .= "exec $wrapperBinary";
+        $bin .= "exec \"$wrapperBinary\"";
         $pipes = array();
         $this->proc = proc_open($bin, self::$descriptorspec, $pipes);
         $this->pipes = $pipes;


### PR DESCRIPTION
This PR fixes the following situation:

```
[development@localhost ~/P/no-spaces] (paratest) ./phpunit-parallel.sh 

Running phpunit in 10 processes with phpunit

Configuration read from /home/development/Projects/no-spaces/phpunit.xml

................................................................. 65 / 76 ( 85%)
........................

Time: 10.07 seconds, Memory: 7.75Mb

OK (89 tests, 903 assertions)
[development@localhost ~/P/no-spaces] (paratest) cd ..
[development@localhost ~/Projects] mv no-spaces/ "with spaces"
[development@localhost ~/Projects] cd with\ spaces/
[development@localhost ~/P/with spaces] (paratest) ./phpunit-parallel.sh 
Running phpunit in 10 processes with phpunit

Configuration read from /home/development/Projects/with spaces/phpunit.xml



                                                            
  [RuntimeException]                                        
  This worker has crashed. Last executed command:           
  Output:                                                   
  ----------------------                                    
  ----------------------                                    
  sh: 1: exec: /home/development/Projects/with: not found  
                                                            

paratest [-p|--processes PROCESSES] [-f|--functional] [--no-test-tokens] [-h|--help] [--coverage-clover COVERAGE-CLOVER] [--coverage-html COVERAGE-HTML] [--coverage-php COVERAGE-PHP] [-m|--max-batch-size MAX-BATCH-SIZE] [--filter FILTER] [--phpunit PHPUNIT] [--runner RUNNER] [--bootstrap BOOTSTRAP] [-c|--configuration CONFIGURATION] [-g|--group GROUP] [--exclude-group EXCLUDE-GROUP] [--stop-on-failure] [--log-junit LOG-JUNIT] [--colors] [--testsuite [TESTSUITE]] [--path PATH] [--] [<path>]

```