### PR TITLE
[WIP] phpunit version compliant build matrix excludes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,16 @@ cache:
 matrix:
   fast_finish: true
   exclude:
-    - php: 5.4
-        env: PHPUNIT_VERSION='5.*@stable'
-        env: PHPUNIT_VERSION='*@dev'
-    - php: 5.5
-        env: PHPUNIT_VERSION='5.*@stable'
-        env: PHPUNIT_VERSION='*@dev'
-    - php: 7.0
-        env: PHPUNIT_VERSION='4.*@stable'
-    - php: 7.0
-        env: PHPUNIT_VERSION='3.7.*@stable'
+  - php: 5.4
+      env: PHPUNIT_VERSION='5.*@stable'
+      env: PHPUNIT_VERSION='*@dev'
+  - php: 5.5
+      env: PHPUNIT_VERSION='5.*@stable'
+      env: PHPUNIT_VERSION='*@dev'
+  - php: 7.0
+      env: PHPUNIT_VERSION='4.*@stable'
+  - php: 7.0
+      env: PHPUNIT_VERSION='3.7.*@stable'
   allow_failures:
     - env: PHPUNIT_VERSION='*@dev'
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,16 @@ cache:
 matrix:
   fast_finish: true
   exclude:
-	- php: 5.4
-		env: PHPUNIT_VERSION='5.*@stable'
-		env: PHPUNIT_VERSION='*@dev'
-	- php: 5.5
-		env: PHPUNIT_VERSION='5.*@stable'
-		env: PHPUNIT_VERSION='*@dev'
-	- php: 7.0
-		env: PHPUNIT_VERSION='4.*@stable'
-	- php: 7.0
-		env: PHPUNIT_VERSION='3.7.*@stable'
+    - php: 5.4
+        env: PHPUNIT_VERSION='5.*@stable'
+        env: PHPUNIT_VERSION='*@dev'
+    - php: 5.5
+        env: PHPUNIT_VERSION='5.*@stable'
+        env: PHPUNIT_VERSION='*@dev'
+    - php: 7.0
+        env: PHPUNIT_VERSION='4.*@stable'
+    - php: 7.0
+        env: PHPUNIT_VERSION='3.7.*@stable'
   allow_failures:
     - env: PHPUNIT_VERSION='*@dev'
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,17 @@ cache:
 
 matrix:
   fast_finish: true
+  exclude:
+	- php: 5.4
+		env: PHPUNIT_VERSION='5.*@stable'
+		env: PHPUNIT_VERSION='*@dev'
+	- php: 5.5
+		env: PHPUNIT_VERSION='5.*@stable'
+		env: PHPUNIT_VERSION='*@dev'
+	- php: 7.0
+		env: PHPUNIT_VERSION='4.*@stable'
+	- php: 7.0
+		env: PHPUNIT_VERSION='3.7.*@stable'
   allow_failures:
     - env: PHPUNIT_VERSION='*@dev'
     - php: 7.0


### PR DESCRIPTION
a PR seems to be the only way to try out travis configurations...
PHPUnit has the following constraints:
* PHPUnit 4.8 is supported on PHP 5.3, PHP 5.4, PHP 5.5, and PHP 5.6.
* PHPUnit 5.0 is supported on PHP 5.6 and PHP 7.

This travis-config tries to execute only supported version combinations.