### PR TITLE
PHP 7 & PHPUnit 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: PHPUNIT_VERSION='*@dev'
+  exclude:
+    - php: 5.5
+      env: PHPUNIT_VERSION='5.*@stable'
 
 env:
     - PHPUNIT_VERSION='3.7.*@stable'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: PHPUNIT_VERSION='*@dev'
-    - php: 7.0
 
 env:
     - PHPUNIT_VERSION='3.7.*@stable'

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "brianium/habitat": "1.0.0",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "ext-pcre": "*"
+        "ext-pcre": "*",
+        "composer/semver": "~1.2.0"
     },
     "type": "library",
     "description": "Parallel testing for PHP",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,4 +18,10 @@
             <directory>./test/functional/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/ParaTest/Console/Commands/ParaTestCommand.php
+++ b/src/ParaTest/Console/Commands/ParaTestCommand.php
@@ -1,5 +1,6 @@
 <?php namespace ParaTest\Console\Commands;
 
+use Composer\Semver\Comparator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,6 +22,14 @@ class ParaTestCommand extends Command
     }
 
     /**
+     * @return bool
+     */
+    public static function isWhitelistSupported()
+    {
+        return Comparator::greaterThanOrEqualTo(\PHPUnit_Runner_Version::id(), '5.0.0');
+    }
+
+    /**
      * Ubiquitous configuration options for ParaTest
      */
     protected function configure()
@@ -33,9 +42,12 @@ class ParaTestCommand extends Command
             ->addOption('coverage-clover', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in Clover XML format.')
             ->addOption('coverage-html', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in HTML format.')
             ->addOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.')
-            ->addOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.')
             ->addOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0)
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).');
+
+        if (self::isWhitelistSupported()) {
+            $this->addOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.');
+        }
     }
 
     /**

--- a/src/ParaTest/Console/Commands/ParaTestCommand.php
+++ b/src/ParaTest/Console/Commands/ParaTestCommand.php
@@ -33,6 +33,7 @@ class ParaTestCommand extends Command
             ->addOption('coverage-clover', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in Clover XML format.')
             ->addOption('coverage-html', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in HTML format.')
             ->addOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.')
+            ->addOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.')
             ->addOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0)
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).');
     }

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -213,6 +213,9 @@ class PHPUnitTest extends FunctionalTestBase
 
     public function testRunWithFatalRuntimeErrorsHasExitCode1()
     {
+        if (PHP_VERSION_ID >= 70000) {
+            $this->markTestSkipped('fatals are handled like normal exceptions with php7');
+        }
         $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', array(
             'bootstrap' => BOOTSTRAP
         ));
@@ -221,6 +224,9 @@ class PHPUnitTest extends FunctionalTestBase
 
     public function testRunWithFatalRuntimeErrorOutputsError()
     {
+        if (PHP_VERSION_ID >= 70000) {
+            $this->markTestSkipped('fatals are handled like normal exceptions with php7');
+        }
         $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', array(
             'bootstrap' => BOOTSTRAP
         ));
@@ -229,6 +235,9 @@ class PHPUnitTest extends FunctionalTestBase
 
     public function testRunWithFatalRuntimeErrorWithTheWrapperRunnerOutputsError()
     {
+        if (PHP_VERSION_ID >= 70000) {
+            $this->markTestSkipped('fatals are handled like normal exceptions with php7');
+        }
         $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', array(
             'bootstrap' => BOOTSTRAP,
             'runner' => 'WrapperRunner'

--- a/test/functional/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
+++ b/test/functional/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php namespace ParaTest\Runners\PHPUnit;
 
+use ParaTest\Console\Commands\ParaTestCommand;
+
 class RunnerIntegrationTest extends \TestBase
 {
     /** @var Runner $runner */
@@ -16,11 +18,13 @@ class RunnerIntegrationTest extends \TestBase
 
         $this->options = array(
             'path' => FIXTURES . DS . 'failing-tests',
-            'whitelist' => FIXTURES . DS . 'failing-tests',
             'phpunit' => PHPUNIT,
             'coverage-php' => sys_get_temp_dir() . DS . 'testcoverage.php',
             'bootstrap' => BOOTSTRAP
         );
+        if (ParaTestCommand::isWhitelistSupported()) {
+            $this->options['whitelist'] = FIXTURES . DS . 'failing-tests';
+        }
         $this->runner = new Runner($this->options);
     }
 

--- a/test/functional/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
+++ b/test/functional/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
@@ -2,6 +2,7 @@
 
 class RunnerIntegrationTest extends \TestBase
 {
+    /** @var Runner $runner */
     protected $runner;
     protected $options;
 
@@ -15,6 +16,7 @@ class RunnerIntegrationTest extends \TestBase
 
         $this->options = array(
             'path' => FIXTURES . DS . 'failing-tests',
+            'whitelist' => FIXTURES . DS . 'failing-tests',
             'phpunit' => PHPUNIT,
             'coverage-php' => sys_get_temp_dir() . DS . 'testcoverage.php',
             'bootstrap' => BOOTSTRAP

--- a/test/functional/WrapperRunnerTest.php
+++ b/test/functional/WrapperRunnerTest.php
@@ -42,6 +42,9 @@ class WrapperRunnerTest extends FunctionalTestBase
 
     public function testFatalErrorsAreReported()
     {
+        if (PHP_VERSION_ID >= 70000) {
+            $this->markTestSkipped('fatals are handled like normal exceptions with php7');
+        }
         $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', array(
             'runner' => 'WrapperRunner',
             'processes' => 1,

--- a/test/unit/ParaTest/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/ParaTest/Console/Commands/ParaTestCommandTest.php
@@ -47,6 +47,7 @@ class ParaTestCommandTest extends \TestBase
             new InputOption('coverage-clover', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in Clover XML format.'),
             new InputOption('coverage-html', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in HTML format.'),
             new InputOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.'),
+            new InputOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.'),
             new InputOption('testsuite', null, InputOption::VALUE_OPTIONAL, 'Filter which testsuite to run'),
             new InputOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0),
             new InputOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).'),

--- a/test/unit/ParaTest/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/ParaTest/Console/Commands/ParaTestCommandTest.php
@@ -28,7 +28,7 @@ class ParaTestCommandTest extends \TestBase
      */
     public function testConfiguredDefinitionWithPHPUnitTester()
     {
-        $expected = new InputDefinition(array(
+        $options = array(
             new InputOption('processes', 'p', InputOption::VALUE_REQUIRED, 'The number of test processes to run.', 5),
             new InputOption('functional', 'f', InputOption::VALUE_NONE, 'Run methods instead of suites in separate processes.'),
             new InputOption('help', 'h', InputOption::VALUE_NONE, 'Display this help message.'),
@@ -47,11 +47,14 @@ class ParaTestCommandTest extends \TestBase
             new InputOption('coverage-clover', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in Clover XML format.'),
             new InputOption('coverage-html', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in HTML format.'),
             new InputOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.'),
-            new InputOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.'),
             new InputOption('testsuite', null, InputOption::VALUE_OPTIONAL, 'Filter which testsuite to run'),
             new InputOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0),
             new InputOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).'),
-        ));
+        );
+        if (ParaTestCommand::isWhitelistSupported()) {
+            $options[] = new InputOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.');
+        }
+        $expected = new InputDefinition($options);
         $definition = $this->command->getDefinition();
         $this->assertEquals($expected, $definition);
     }

--- a/test/unit/ParaTest/Coverage/CoverageMergerTest.php
+++ b/test/unit/ParaTest/Coverage/CoverageMergerTest.php
@@ -18,7 +18,9 @@ class CoverageMergerTest extends \PHPUnit_Framework_TestCase
         $firstFile = PARATEST_ROOT . '/src/ParaTest/Logging/LogInterpreter.php';
         $secondFile = PARATEST_ROOT . '/src/ParaTest/Logging/MetaProvider.php';
 
-        $coverage1 = new \PHP_CodeCoverage();
+        $filter = new \PHP_CodeCoverage_Filter();
+        $filter->addFilesToWhitelist([$firstFile, $secondFile]);
+        $coverage1 = new \PHP_CodeCoverage(null, $filter);
         $coverage1->append(
             array(
                 $firstFile => array(35 => 1),
@@ -26,7 +28,7 @@ class CoverageMergerTest extends \PHPUnit_Framework_TestCase
             ),
             'Test1'
         );
-        $coverage2 = new \PHP_CodeCoverage();
+        $coverage2 = new \PHP_CodeCoverage(null, $filter);
         $coverage2->append(
             array(
                 $firstFile => array(35 => 1, 36 => 1)


### PR DESCRIPTION
This adds fixes to support php 7 and phpunit 5. ( fixes #189 and #162 )
It is mainly build-/test-related:
* with php 7, phpunit catches fatal errors like normal errors => no special failure handling neccessary, they are skipped with
```PHP
if (PHP_VERSION_ID >= 70000) {
    $this->markTestSkipped('fatals are handled like normal exceptions with php7');
}
```
* phpunit 5 requires a whitelist to be defined when tracking coverage

the fix for this adds a deep dependency to phpunit, because paratest can only support the ```--whitelist``` option, when phpunit does, and it does only for versions >=5.0.0
```PHP
public static function isWhitelistSupported() {
    return Comparator::greaterThanOrEqualTo(\PHPUnit_Runner_Version::id(), '5.0.0');
}
```

So I need some feedback here, especially from @brianium (and anyone else interested) whether this is justifiable or we have better options.

PS: the current phpunit-dev-master does not work anymore so there must be a problem introduced after phpunit 5.1.0, but I couldn't track it down yet