### PR TITLE
Update SuitePath.php

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/SuitePath.php
+++ b/src/ParaTest/Runners/PHPUnit/SuitePath.php
@@ -25,7 +25,7 @@ class SuitePath
     
     public function __construct($path, $excludedPaths, $suffix)
     {
-        if ($suffix === null) {
+        if (empty($suffix)) {
             $suffix = self::DEFAULT_SUFFIX;
         }
         $this->path = $path;


### PR DESCRIPTION
Get this Warning: preg_quote() expects parameter 1 to be string, array given in brianium/paratest/src/ParaTest/Runners/PHPUnit/SuitePath.php

Due to suffix being an empty array in the construtor