### PR TITLE
Fix some documentation issues found in Scrutinizer

### DIFF
--- a/src/ParaTest/Logging/LogInterpreter.php
+++ b/src/ParaTest/Logging/LogInterpreter.php
@@ -5,6 +5,12 @@ use ParaTest\Logging\JUnit\Reader;
 use ParaTest\Logging\JUnit\TestSuite;
 use ParaTest\Logging\MetaProvider;
 
+/**
+ * Class LogInterpreter
+ * @package ParaTest\Logging
+ * @method array getFailures
+ * @method array getErrors
+ */
 class LogInterpreter extends MetaProvider
 {
     /**

--- a/src/ParaTest/Logging/LogInterpreter.php
+++ b/src/ParaTest/Logging/LogInterpreter.php
@@ -6,8 +6,6 @@ use ParaTest\Logging\JUnit\TestSuite;
 use ParaTest\Logging\MetaProvider;
 
 /**
- * Class LogInterpreter
- * @package ParaTest\Logging
  * @method array getFailures
  * @method array getErrors
  */

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -8,6 +8,10 @@ namespace ParaTest\Runners\PHPUnit;
  * to run PHPUnit via ParaTest
  *
  * @package ParaTest\Runners\PHPUnit
+ * @property-read int $processes
+ * @property-read string $phpunit
+ * @property-read string $functional
+ * @property-read array $filtered
  */
 class Options
 {
@@ -64,6 +68,15 @@ class Options
      * @var array
      */
     protected $annotations = array();
+
+    protected $runner;
+    protected $noTestTokens;
+    protected $colors;
+    protected $testsuite;
+    protected $maxBatchSize;
+    protected $filter;
+    protected $groups;
+    protected $excludeGroups;
 
     public function __construct($opts = array())
     {

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -13,13 +13,15 @@ namespace ParaTest\Runners\PHPUnit;
  * @property-read string $functional
  * @property-read array $filtered
  * @property-read $runner
- * @property-read $noTestTokens
+ * @property-read bool $noTestTokens
  * @property-read string $colors
  * @property-read string $testsuite
  * @property-read int $maxBatchSize
- * @property-read $filter
+ * @property-read string $filter
  * @property-read string[] $groups
  * @property-read string[] $excludeGroups
+ * @property-read array $annotations
+ * @property-read string $path
  */
 class Options
 {

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -12,6 +12,14 @@ namespace ParaTest\Runners\PHPUnit;
  * @property-read string $phpunit
  * @property-read string $functional
  * @property-read array $filtered
+ * @property-read $runner
+ * @property-read $noTestTokens
+ * @property-read string $colors
+ * @property-read string $testsuite
+ * @property-read int $maxBatchSize
+ * @property-read $filter
+ * @property-read string[] $groups
+ * @property-read string[] $excludeGroups
  */
 class Options
 {

--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -437,7 +437,7 @@ class ResultPrinter
             ($count == 1) ? '' : 's'
         );
 
-        for ($i = 1; $i <= sizeof($defects); $i++) {
+        for ($i = 1, $max = sizeof($defects); $i <= $max; $i++) {
             $output .= sprintf("\n%d) %s\n", $i, $defects[$i - 1]);
         }
 

--- a/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
+++ b/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
@@ -22,6 +22,11 @@ class SuiteLoader
      */
     protected $loadedSuites = array();
 
+    /**
+     * @var Options
+     */
+    private $options;
+
     public function __construct($options = null)
     {
         if ($options && !$options instanceof Options) {

--- a/src/ParaTest/Runners/PHPUnit/TestFileLoader.php
+++ b/src/ParaTest/Runners/PHPUnit/TestFileLoader.php
@@ -45,6 +45,10 @@ class TestFileLoader
      */
     protected $excludingFiles = false;
 
+    /**
+     * @var Options
+     */
+    private $options;
 
     public function __construct($options = null)
     {


### PR DESCRIPTION
Fixed some of the issues found in Scrutinizer:

* PHPDoc for read-only properties
* Defined protected properties for some dynamically defined properties.