### PR TITLE
Change unit test assertion depending on the version of PHPUnit being used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "brianium/paratest",
     "require": {
         "php": ">=5.4.0",
-        "phpunit/phpunit": ">=3.7.8",
+        "phpunit/phpunit": "4.*@stable",
         "phpunit/php-timer": ">=1.0.4",
         "symfony/console": "~2.3|~3.0",
         "symfony/process": "~2.3|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "brianium/paratest",
     "require": {
         "php": ">=5.4.0",
-        "phpunit/phpunit": "4.*@stable",
+        "phpunit/phpunit": ">=3.7.8",
         "phpunit/php-timer": ">=1.0.4",
         "symfony/console": "~2.3|~3.0",
         "symfony/process": "~2.3|~3.0",

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
-if(!defined('DS'))
+
+if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
+}
 
 require_once dirname(__DIR__) . DS . 'vendor' . DS . 'autoload.php';
 
@@ -16,7 +18,7 @@ define("PARATEST_ROOT", dirname(__DIR__));
 
 //check for .bat first if on windows.
 $phpunit_path = PARATEST_ROOT . DS . 'vendor' . DS . 'bin' . DS . 'phpunit';
-if(file_exists($phpunit_path . '.bat')) {
+if (file_exists($phpunit_path . '.bat')) {
     $phpunit_path = $phpunit_path . '.bat';
 }
 define("PHPUNIT", $phpunit_path);

--- a/test/functional/FunctionalTestBase.php
+++ b/test/functional/FunctionalTestBase.php
@@ -8,8 +8,9 @@ class FunctionalTestBase extends PHPUnit_Framework_TestCase
     protected function fixture($fixture)
     {
         $fixture = FIXTURES . DS . $fixture;
-        if(!file_exists($fixture))
+        if (!file_exists($fixture)) {
             throw new Exception("Fixture $fixture not found");
+        }
 
         return $fixture;
     }
@@ -20,7 +21,7 @@ class FunctionalTestBase extends PHPUnit_Framework_TestCase
         return $invoker->execute($options, $callback);
     }
 
-    protected function assertTestsPassed(Process $proc, $testPattern='\d+', $assertionPattern='\d+')
+    protected function assertTestsPassed(Process $proc, $testPattern = '\d+', $assertionPattern = '\d+')
     {
         $this->assertRegExp(
             "/OK \($testPattern tests?, $assertionPattern assertions?\)/",

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -307,17 +307,6 @@ class PHPUnitTest extends FunctionalTestBase
         $this->assertTestsPassed($proc, 2, 2);
     }
 
-    public function testTestsWithWarningsResultInFailure()
-    {
-        $proc = $this->invokeParatest("warning-tests/HasWarningsTest.php",
-            array('bootstrap' => BOOTSTRAP)
-        );
-
-        $proc->getOutput();
-
-        $this->assertEquals(1, $proc->getExitCode(), "Test should fail with 1");
-    }
-
     public function setsCoveragePhpDataProvider()
     {
         return array(

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Specifically tests warnings when using PHPUnit 4.8 and below
+ * Specifically tests warnings in PHPUnit
  */
 class PHPUnitWarningsTest extends FunctionalTestBase
 {

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Specifically tests warnings when using PHPUnit 4.8 and below
+ */
+class PHPUnitWarningsTest extends FunctionalTestBase
+{
+    public function testTestsWithWarningsResultInFailure()
+    {
+        $proc = $this->invokeParatest(
+            "warning-tests/HasWarningsTest.php",
+            array('bootstrap' => BOOTSTRAP)
+        );
+
+        $output = $proc->getOutput();
+
+        if (version_compare(PHP_VERSION, '5.6.0', '>=')) {
+            // PHPUnit 5.1+ Changed how it handles test warnings (not E_WARNINGS)
+            $this->assertContains("Warnings", $output, "Test should output warnings");
+            $this->assertEquals(0, $proc->getExitCode(), "Test suite should succeed with 0");
+        } else {
+            // PHPUnit 4.8 and below failed the test suite if a test warning occurred
+            $this->assertEquals(1, $proc->getExitCode(), "Test suite should fail with 1");
+        }
+    }
+}

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -14,7 +14,7 @@ class PHPUnitWarningsTest extends FunctionalTestBase
 
         $output = $proc->getOutput();
 
-        if (version_compare(PHP_VERSION, '5.6.0', '>=')) {
+        if (version_compare(PHPUnit_Runner_Version::id(), '5.1.0', '>=')) {
             // PHPUnit 5.1+ Changed how it handles test warnings (not E_WARNINGS)
             $this->assertContains("Warnings", $output, "Test should output warnings");
             $this->assertEquals(0, $proc->getExitCode(), "Test suite should succeed with 0");

--- a/test/unit/ParaTest/Coverage/CoverageMergerTest.php
+++ b/test/unit/ParaTest/Coverage/CoverageMergerTest.php
@@ -8,7 +8,7 @@ class CoverageMergerTest extends \PHPUnit_Framework_TestCase
     {
         try {
             $coverage = new \PHP_CodeCoverage();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $this->markTestSkipped($e->getMessage());
         }
     }
@@ -42,6 +42,8 @@ class CoverageMergerTest extends \PHPUnit_Framework_TestCase
         $coverage = $merger->getCoverage();
 
         $data = $coverage->getData();
+        var_dump($data);
+
         $this->assertEquals(2, count($data[$firstFile][35]));
         $this->assertEquals('Test1', $data[$firstFile][35][0]);
         $this->assertEquals('Test2', $data[$firstFile][35][1]);

--- a/test/unit/ParaTest/Coverage/CoverageMergerTest.php
+++ b/test/unit/ParaTest/Coverage/CoverageMergerTest.php
@@ -42,7 +42,6 @@ class CoverageMergerTest extends \PHPUnit_Framework_TestCase
         $coverage = $merger->getCoverage();
 
         $data = $coverage->getData();
-        var_dump($data);
 
         $this->assertEquals(2, count($data[$firstFile][35]));
         $this->assertEquals('Test1', $data[$firstFile][35][0]);


### PR DESCRIPTION
As described below in comments, PHPUnit 5.1+ changed the way test warnings are treated in test suites. This is not to be confused with E_WARNINGS that are raised during tests. These are things like "test method is marked as private" or "non-existent data provider specified". In PHPUnit 4.8 these were printed as warnings in the test output, and they also caused a failed build (exit code > 0). In PHPUnit 5.1+ these still output warnings, but they do NOT output a failed exit code.

This PR adds a PHPUnit version check to change the assertion based on what we actually expect to happen.