### PR TITLE
Fix failed build (Mb/MB check and require php-code-coverage 3.X)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-simplexml": "*",
         "ext-pcre": "*",
         "composer/semver": "~1.2",
-        "phpunit/php-code-coverage": "3.*"
+        "phpunit/php-code-coverage": "<=3.3.9"
     },
     "type": "library",
     "description": "Parallel testing for PHP",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "ext-reflection": "*",
         "ext-simplexml": "*",
         "ext-pcre": "*",
-        "composer/semver": "~1.2"
+        "composer/semver": "~1.2",
+        "phpunit/php-code-coverage": "3.*"
     },
     "type": "library",
     "description": "Parallel testing for PHP",

--- a/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
@@ -128,7 +128,7 @@ class ResultPrinterTest extends ResultTester
         $this->assertRegExp(
             "/\n\nTime: [0-9]+([.][0-9]{1,2})? " .
             "(minute|minutes|second|seconds|ms)?," .
-            " Memory:[\s][0-9]+([.][0-9]{1,2})?Mb\n\n/",
+            " Memory:[\s][0-9]+([.][0-9]{1,2})?M[Bb]\n\n/",
             $header
         );
     }


### PR DESCRIPTION
# MB vs Mb string check

This should allow for differences in environments/versions which check the memory usage output string. Sometimes its X.XXMB and other times it's X.XXMb.

# PHP_CodeCoverage

Paratest depends directly on PHP_CodeCoverage via its code, however it does not explicity require it in composer.json. Instead it relies on the inclusion through phpunit. A recent version of phpunit completely changed the class structure of PHP CodeCoverage, so for now I simply did `composer require "phpunit/php-code-coverage:3.*"` to fix this. This [automatically] locks the project to [a maximum of] PHPUnit 5.3.5 which is the last version that supported this. 