### PR TITLE
allow multiple instances of paratest running at the same time

### DIFF
--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -143,7 +143,7 @@ class PHPUnit extends Tester
         $this->requireBootstrap($bootstrap);
 
         if ($this->hasCoverage($options)) {
-            $options['coverage-php'] = sys_get_temp_dir() . '/will_be_overwritten.php';
+            $options['coverage-php'] = tempnam(sys_get_temp_dir(), 'paratest_');
         }
 
         if ($path) {

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -312,11 +312,11 @@ class PHPUnitTest extends FunctionalTestBase
         return array(
             array(
                 array('coverage-html' => 'wayne'),
-                sys_get_temp_dir() . '/will_be_overwritten.php'
+                ''
             ),
             array(
                 array('coverage-clover' => 'wayne'),
-                sys_get_temp_dir() . '/will_be_overwritten.php'
+                ''
             ),
             array(
                 array('coverage-php' => 'notWayne'),
@@ -347,6 +347,10 @@ class PHPUnitTest extends FunctionalTestBase
         $input->setArgument('path', '.');
         $options = $phpUnit->getRunnerOptions($input);
 
-        $this->assertEquals($coveragePhp, $options['coverage-php']);
+        if ($coveragePhp) {
+            $this->assertEquals($coveragePhp, $options['coverage-php']);
+        } else {
+            $this->assertStringStartsWith(sys_get_temp_dir() . '/paratest_', $options['coverage-php']);
+        }
     }
 }


### PR DESCRIPTION
When I run paratest on two projects at the same time I run into problems because the temporary file with coverage data has a static name. This PR makes the name dynamic leveraging `tempnam()`. 