### PR TITLE
Fixes #202 Remove null byte from anonymous class reflection name

### DIFF
--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 namespace ParaTest\Console\Testers;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/ParaTest/Parser/Parser.php
+++ b/src/ParaTest/Parser/Parser.php
@@ -62,10 +62,20 @@ class Parser
             ? null
             : new ParsedClass(
                 $this->refl->getDocComment(),
-                $this->refl->getName(),
+                $this->getCleanReflectionName(),
                 $this->refl->getNamespaceName(),
                 $this->getMethods()
             );
+    }
+
+    /**
+     * Return reflection name with null bytes stripped
+     *
+     * @return string
+     */
+    private function getCleanReflectionName()
+    {
+        return str_replace("\x00", '', $this->refl->getName());
     }
 
     /**

--- a/test/fixtures/failing-tests/AnonymousClass.inc
+++ b/test/fixtures/failing-tests/AnonymousClass.inc
@@ -1,0 +1,13 @@
+<?php
+
+new class() {
+    /**
+     * @return class
+     */
+    public function testAnonymousClass()
+    {
+        return new class()
+        {
+        };
+    }
+};

--- a/test/unit/ParaTest/Parser/ParserTest/GetClassTest.php
+++ b/test/unit/ParaTest/Parser/ParserTest/GetClassTest.php
@@ -21,6 +21,16 @@ class ParserTest_GetClassTest extends \TestBase
         $this->assertEquals('Fixtures\\Tests\\UnitTestWithClassAnnotationTest', $class->getName());
     }
 
+    public function testParsedAnonymousClassNameHasNoNullByte()
+    {
+        if (PHP_VERSION_ID < 70000) {
+            return $this->markTestSkipped('php versions prior to php7 does not support anonymous classes');
+        }
+
+        $class = $this->parseFile($this->fixture('failing-tests/AnonymousClass.inc'));
+        $this->assertNotContains("\x00", $class->getName());
+    }
+
     public function testParsedClassHasDocBlock()
     {
         $class = $this->parseFile($this->fixture('failing-tests/UnitTestWithClassAnnotationTest.php'));


### PR DESCRIPTION
Since php7's anonymous class names contain null bytes, we've encountered some issues with paratests' Parser-class.
This fix remove said null byte, to avoid obscure failures.