### PR TITLE
Support PHPUnit its --repeat option

### DIFF
--- a/src/ParaTest/Console/Commands/ParaTestCommand.php
+++ b/src/ParaTest/Console/Commands/ParaTestCommand.php
@@ -43,7 +43,9 @@ class ParaTestCommand extends Command
             ->addOption('coverage-html', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in HTML format.')
             ->addOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.')
             ->addOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0)
-            ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).');
+            ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).')
+            ->addOption('repeat', null, InputOption::VALUE_REQUIRED, 'Repeat failing tests.', 0);
+
 
         if (self::isWhitelistSupported()) {
             $this->addOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.');

--- a/src/ParaTest/Console/Commands/ParaTestCommand.php
+++ b/src/ParaTest/Console/Commands/ParaTestCommand.php
@@ -44,7 +44,7 @@ class ParaTestCommand extends Command
             ->addOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.')
             ->addOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0)
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).')
-            ->addOption('repeat', null, InputOption::VALUE_REQUIRED, 'Repeat failing tests.', 0);
+            ->addOption('repeat', null, InputOption::VALUE_REQUIRED, 'Runs the test(s) repeatedly.', 1);
 
 
         if (self::isWhitelistSupported()) {

--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -80,8 +80,19 @@ class PHPUnit extends Tester
             $runner = new Runner($this->getRunnerOptions($input));
         }
 
-        $runner->run();
-        return $runner->getExitCode();
+        // Allow the tests to be repeated.
+        $statusCode = 0;
+        $repeat = $input->getOption('repeat') ?: 1;
+        for ($i = 0; $i < $repeat; $i++) {
+            $runner->run();
+            $status = $runner->getExitCode();
+            $statusCode = $status ? $status : $statusCode;
+        }
+
+        // Print all messages at the end.
+        $runner->complete();
+
+        return $statusCode;
     }
 
     /**

--- a/src/ParaTest/Runners/PHPUnit/BaseRunner.php
+++ b/src/ParaTest/Runners/PHPUnit/BaseRunner.php
@@ -59,6 +59,13 @@ abstract class BaseRunner
      */
     protected $coverage = null;
 
+    /**
+     * Indicates whether the starting messages was printed or not.
+     *
+     * @var bool
+     */
+    protected $starting_messages_printed = false;
+
 
     public function __construct($opts = array())
     {
@@ -72,7 +79,12 @@ abstract class BaseRunner
         $this->verifyConfiguration();
         $this->initCoverage();
         $this->load();
-        $this->printer->start($this->options);
+
+        // Print the starting messages only if they we not printed.
+        if (!$this->starting_messages_printed) {
+            $this->printer->start($this->options);
+            $this->starting_messages_printed = true;
+        }
     }
 
     /**

--- a/src/ParaTest/Runners/PHPUnit/BaseRunner.php
+++ b/src/ParaTest/Runners/PHPUnit/BaseRunner.php
@@ -60,7 +60,7 @@ abstract class BaseRunner
     protected $coverage = null;
 
     /**
-     * Indicates whether the starting messages was printed or not.
+     * Indicates whether the starting messages were printed or not.
      *
      * @var bool
      */
@@ -80,7 +80,7 @@ abstract class BaseRunner
         $this->initCoverage();
         $this->load();
 
-        // Print the starting messages only if they we not printed.
+        // Print the starting messages only if they were not printed yet.
         if (!$this->starting_messages_printed) {
             $this->printer->start($this->options);
             $this->starting_messages_printed = true;

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -58,6 +58,13 @@ class Options
     protected $filtered;
 
     /**
+     * The number of times that a test needs to be repeated.
+     *
+     * @var int
+     */
+    protected $repeat;
+
+    /**
      * A collection of option values directly corresponding
      * to certain annotations - i.e group
      *
@@ -82,6 +89,7 @@ class Options
         $this->testsuite = $opts['testsuite'];
         $this->maxBatchSize = $opts['max-batch-size'];
         $this->filter = $opts['filter'];
+        $this->repeat = $opts['repeat'];
 
         // we need to register that options if they are blank but do not get them as
         // key with null value in $this->filtered as it will create problems for
@@ -133,7 +141,8 @@ class Options
             'colors' => false,
             'testsuite' => '',
             'max-batch-size' => 0,
-            'filter' => null
+            'filter' => null,
+            'repeat' => 0,
         );
     }
 
@@ -196,7 +205,8 @@ class Options
             'colors' => $this->colors,
             'testsuite' => $this->testsuite,
             'max-batch-size' => $this->maxBatchSize,
-            'filter' => $this->filter
+            'filter' => $this->filter,
+            'repeat' => $this->repeat,
         ));
         if ($configuration = $this->getConfigurationPath($filtered)) {
             $filtered['configuration'] = new Configuration($configuration);

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -142,7 +142,7 @@ class Options
             'testsuite' => '',
             'max-batch-size' => 0,
             'filter' => null,
-            'repeat' => 0,
+            'repeat' => 1
         );
     }
 

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -206,7 +206,7 @@ class Options
             'testsuite' => $this->testsuite,
             'max-batch-size' => $this->maxBatchSize,
             'filter' => $this->filter,
-            'repeat' => $this->repeat,
+            'repeat' => $this->repeat
         ));
         if ($configuration = $this->getConfigurationPath($filtered)) {
             $filtered['configuration'] = new Configuration($configuration);

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -37,6 +37,7 @@ class Runner extends BaseRunner
             $this->fillRunQueue();
             usleep(10000);
         }
+        $this->complete();
     }
 
     /**

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -37,7 +37,6 @@ class Runner extends BaseRunner
             $this->fillRunQueue();
             usleep(10000);
         }
-        $this->complete();
     }
 
     /**
@@ -46,7 +45,7 @@ class Runner extends BaseRunner
      * logs any results to JUnit, and cleans up temporary
      * files
      */
-    private function complete()
+    public function complete()
     {
         $this->printer->printResults();
         $this->interpreter->rewind();

--- a/src/ParaTest/Runners/PHPUnit/WrapperRunner.php
+++ b/src/ParaTest/Runners/PHPUnit/WrapperRunner.php
@@ -148,7 +148,7 @@ class WrapperRunner extends BaseRunner
         return $streams;
     }
 
-    private function complete()
+    public function complete()
     {
         $this->setExitCode();
         $this->printer->printResults();

--- a/test/functional/EmptyRunnerStub.php
+++ b/test/functional/EmptyRunnerStub.php
@@ -10,6 +10,10 @@
  */
 class EmptyRunnerStub extends \ParaTest\Runners\PHPUnit\BaseRunner
 {
+    public function complete()
+    {
+    }
+
     public function run()
     {
         echo "EXECUTED";

--- a/test/unit/ParaTest/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/ParaTest/Console/Commands/ParaTestCommandTest.php
@@ -50,6 +50,7 @@ class ParaTestCommandTest extends \TestBase
             new InputOption('testsuite', null, InputOption::VALUE_OPTIONAL, 'Filter which testsuite to run'),
             new InputOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0),
             new InputOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).'),
+            new InputOption('repeat', null, InputOption::VALUE_REQUIRED, 'Runs the test(s) repeatedly.', 1),
         );
         if (ParaTestCommand::isWhitelistSupported()) {
             $options[] = new InputOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.');


### PR DESCRIPTION
Provide ParaTest support for PHPUnit its repeat option.

We use the repeat option mostly to run tests on fixes for random failing tests. To prove that the tests succeeds X times in a row. Those are mostly single tests. Then we don't need ParaTest. PHPUnit suffices. But this pull request provides some groundwork for the upcoming support for --only-repeat-failed in ParaTest. An option we already contributed to PHPUnit. See https://github.com/sebastianbergmann/phpunit/pull/1965 
