### PR TITLE
Fix issue 199, prevent empty line attributes in XML

### DIFF
--- a/src/ParaTest/Logging/JUnit/TestCase.php
+++ b/src/ParaTest/Logging/JUnit/TestCase.php
@@ -67,7 +67,8 @@ class TestCase
         $this->name = $name;
         $this->class = $class;
         $this->file = $file;
-        $this->line = $line;
+        // Fix empty line numbers, for proper xml parsing
+        $this->line = empty($line) ? '0' : $line;
         $this->assertions = $assertions;
         $this->time = $time;
     }

--- a/src/ParaTest/Logging/JUnit/TestCase.php
+++ b/src/ParaTest/Logging/JUnit/TestCase.php
@@ -68,7 +68,7 @@ class TestCase
         $this->class = $class;
         $this->file = $file;
         // Fix empty line numbers, for proper xml parsing
-        $this->line = empty($line) ? '0' : $line;
+        $this->line = $line;
         $this->assertions = $assertions;
         $this->time = $time;
     }

--- a/src/ParaTest/Logging/JUnit/TestCase.php
+++ b/src/ParaTest/Logging/JUnit/TestCase.php
@@ -67,7 +67,6 @@ class TestCase
         $this->name = $name;
         $this->class = $class;
         $this->file = $file;
-        // Fix empty line numbers, for proper xml parsing
         $this->line = $line;
         $this->assertions = $assertions;
         $this->time = $time;

--- a/src/ParaTest/Logging/JUnit/Writer.php
+++ b/src/ParaTest/Logging/JUnit/Writer.php
@@ -133,6 +133,10 @@ class Writer
         $vars = get_object_vars($case);
         foreach ($vars as $name => $value) {
             if (preg_match(static::$caseAttrs, $name)) {
+                if ($name === 'line' && empty($value)) {
+                    // Don't output blank line attributes
+                    continue;
+                }
                 $caseNode->setAttribute($name, $value);
             }
         }

--- a/src/ParaTest/Logging/JUnit/Writer.php
+++ b/src/ParaTest/Logging/JUnit/Writer.php
@@ -133,8 +133,7 @@ class Writer
         $vars = get_object_vars($case);
         foreach ($vars as $name => $value) {
             if (preg_match(static::$caseAttrs, $name)) {
-                if ($name === 'line' && empty($value)) {
-                    // Don't output blank line attributes
+                if ($this->isEmptyLineAttribute($name, $value)) {
                     continue;
                 }
                 $caseNode->setAttribute($name, $value);
@@ -201,5 +200,16 @@ class Writer
             $result['time'] += $suite->time;
             return $result;
         }, array_merge(array('name' => $this->name), self::$defaultSuite));
+    }
+
+    /**
+     * Prevent writing empty "line" XML attributes which could break parsers.
+     * @param string $name
+     * @param mixed $value
+     * @return bool
+     */
+    private function isEmptyLineAttribute($name, $value)
+    {
+        return $name === 'line' && empty($value);
     }
 }

--- a/test/fixtures/results/junit-example-result.xml
+++ b/test/fixtures/results/junit-example-result.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="test/fixtures/tests/" tests="7" assertions="6" failures="2" errors="1" time="0.007625">
+        <testsuite name="UnitTestWithClassAnnotationTest" tests="3" assertions="3" failures="1" errors="0" time="0.006109" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php">
+            <testcase name="testTruth" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="10" assertions="1" time="0.001760"/>
+            <testcase name="testFalsehood" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="18" assertions="1" time="0.001195">
+                <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithClassAnnotationTest::testFalsehood
+                    Failed asserting that true is false.
+
+                    /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php:20
+                </failure>
+            </testcase>
+            <testcase name="testArrayLength" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="26" assertions="1" time="0.003154"/>
+        </testsuite>
+        <testsuite name="UnitTestWithErrorTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithErrorTest.php" tests="1" assertions="0" failures="0" errors="1" time="0.000397">
+            <testcase name="testTruth" class="UnitTestWithErrorTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithErrorTest.php" line="" assertions="0" time="0.000397">
+                <error type="Exception">UnitTestWithErrorTest::testTruth
+                    Exception: Error!!!
+
+                    /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithErrorTest.php:12
+                </error>
+            </testcase>
+        </testsuite>
+        <testsuite name="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" tests="3" assertions="3" failures="1" errors="0" time="0.001119">
+            <testcase name="testTruth" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="7" assertions="1" time="0.000341"/>
+            <testcase name="testFalsehood" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="" assertions="1" time="0.000402">
+                <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
+                    Failed asserting that true is false.
+
+                    /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18
+                </failure>
+            </testcase>
+            <testcase name="testArrayLength" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="25" assertions="1" time="0.000376"/>
+        </testsuite>
+    </testsuite>
+</testsuites>

--- a/test/unit/ParaTest/Logging/JUnit/WriterTest.php
+++ b/test/unit/ParaTest/Logging/JUnit/WriterTest.php
@@ -73,6 +73,5 @@ class WriterTest extends \TestBase
         $xml = $writer->getXml();
 
         $this->assertFalse(strpos($xml, 'line=""'), 'Expected no empty line attributes (line=""), but found one.');
-        $this->assertNotEmpty(strpos($xml, 'line="0"'), 'Expected at least one (line="0"), but found none.');
     }
 }

--- a/test/unit/ParaTest/Logging/JUnit/WriterTest.php
+++ b/test/unit/ParaTest/Logging/JUnit/WriterTest.php
@@ -5,19 +5,24 @@ use ParaTest\Logging\LogInterpreter;
 class WriterTest extends \TestBase
 {
     protected $writer;
+
+    /** @var LogInterpreter */
     protected $interpreter;
     protected $passing;
 
     public function setUp()
     {
         $this->interpreter = new LogInterpreter();
-        $this->writer = new Writer($this->interpreter,  "test/fixtures/tests/");
+        $this->writer = new Writer($this->interpreter, "test/fixtures/tests/");
         $this->passing = FIXTURES . DS . 'results' . DS . 'single-passing.xml';
     }
 
     public function testConstructor()
     {
-        $this->assertInstanceOf('ParaTest\\Logging\\LogInterpreter', $this->getObjectValue($this->writer, 'interpreter'));
+        $this->assertInstanceOf(
+            'ParaTest\\Logging\\LogInterpreter',
+            $this->getObjectValue($this->writer, 'interpreter')
+        );
         $this->assertEquals("test/fixtures/tests/", $this->writer->getName());
     }
 
@@ -44,12 +49,30 @@ class WriterTest extends \TestBase
         $this->addPassingReader();
         $this->writer->write($output);
         $this->assertXmlStringEqualsXmlString(file_get_contents($this->passing), file_get_contents($output));
-        if(file_exists($output)) unlink($output);
+        if (file_exists($output)) {
+            unlink($output);
+        }
     }
 
     protected function addPassingReader()
     {
         $reader = new Reader($this->passing);
-        $this->interpreter->addReader($reader);   
+        $this->interpreter->addReader($reader);
+    }
+
+    /**
+     * Empty line attributes, e.g. line="" breaks Jenkins parsing since it needs to be an integer.
+     * To repair, ensure that empty line attributes are actually written as 0 instead of empty string.
+     */
+    public function testThatEmptyLineAttributesConvertToZero()
+    {
+        $mixed = FIXTURES . DS . 'results' . DS . 'junit-example-result.xml';
+        $reader = new Reader($mixed);
+        $this->interpreter->addReader($reader);
+        $writer = new Writer($this->interpreter, "test/fixtures/tests/");
+        $xml = $writer->getXml();
+
+        $this->assertFalse(strpos($xml, 'line=""'), 'Expected no empty line attributes (line=""), but found one.');
+        $this->assertNotEmpty(strpos($xml, 'line="0"'), 'Expected at least one (line="0"), but found none.');
     }
 }


### PR DESCRIPTION
# What

Fixes issue https://github.com/brianium/paratest/issues/199, where the paratest xml writer was allowing empty line numbers, e.g. `line=""`. This is probably due to PHP's loose typing, an empty value could be written as blank instead of `0` which is what we want.

I've written a unit test that uses a fixture xml with some `line=""` instances, and confirms that after writing the output, there is no `line=""` and there is at least one `line="0"` to confirm it changed properly.

The actual code fix is simply to check for an empty string at constructor time, and sets it to `0` if so.
## Side note:

This was created at Digital Ocean's Hacktoberfest in NYC.  (https://hacktoberfest.digitalocean.com/)
