### PR TITLE
Fix temp dir inconsistency on os x

### DIFF
--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -350,7 +350,8 @@ class PHPUnitTest extends FunctionalTestBase
         if ($coveragePhp) {
             $this->assertEquals($coveragePhp, $options['coverage-php']);
         } else {
-            $this->assertStringStartsWith(sys_get_temp_dir() . '/paratest_', $options['coverage-php']);
+            $dir = tempnam(sys_get_temp_dir(), 'paratest_');
+            $this->assertStringStartsWith(dirname($dir), $options['coverage-php']);
         }
     }
 }


### PR DESCRIPTION
On many versions of OS X (including 10.12.1) there are inconsistencies between the temp directory returned by `sys_get_temp_dir()` and the one used by `tempnam()`.

`sys_get_temp_dir()` will return something like:
`/var/folders/0s/rlfsn9993r78qq7qjkr42x2w00058k/T`

`tempname()` will prefix with `/private` as the return value of `sys_get_temp_dir()` may not be writable:
`/private/var/folders/0s/rlfsn9993r78qq7qjkr42x2w00058k/T/paratest_oiqMU3`

This updates the test to take the directory that is returned by `tempnam()`, allowing tests to pass on OSX.