### PR TITLE
Allows groups to be specified, even if test suites do not contain tests for them

### DIFF
--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -216,6 +216,8 @@ class Reader extends MetaProvider
 
         if ($node !== false) {
             $this->suites[] = TestSuite::suiteFromNode($node);
+        } else {
+            $this->suites[] = TestSuite::suiteFromArray(self::$defaultSuite);
         }
     }
 }

--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -74,17 +74,6 @@ class Reader extends MetaProvider
     }
 
     /**
-     * Checks whether the xml log has
-     * test suite results
-     *
-     * @return array
-     */
-    public function hasResults()
-    {
-        return $this->xml->count() > 0;
-    }
-
-    /**
      * Return an array that contains
      * each suite's instant feedback. Since
      * logs do not contain skipped or incomplete

--- a/src/ParaTest/Parser/Parser.php
+++ b/src/ParaTest/Parser/Parser.php
@@ -119,7 +119,8 @@ class Parser
             }
         }
 
-        // Test class was loaded before somehow (referenced from other test class, or explicitly loaded)
+        // Test class was loaded before somehow
+        // (referenced from other test class, explicitly loaded, or filename does not match classname)
         foreach ($classes as $className) {
             $class = new \ReflectionClass($className);
             if ($class->getFileName() == $filename) {

--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -201,16 +201,6 @@ class ResultPrinter
                 $test->getPath()
             ));
         }
-        if (!$reader->hasResults()) {
-            throw new \RuntimeException(sprintf(
-                "The process: %s\nLog file \"%s\" is empty.\n" .
-                "This means a PHPUnit process was unable to run \"%s\"\n" .
-                "Maybe there is more than one class in this file.",
-                $test->getLastCommand(),
-                $test->getTempFile(),
-                $test->getPath()
-            ));
-        }
         $this->results->addReader($reader);
         $this->processReaderFeedback($reader, $test->getTestCount());
         $this->printTestWarnings($test);

--- a/test/unit/ParaTest/Logging/JUnit/ReaderTest.php
+++ b/test/unit/ParaTest/Logging/JUnit/ReaderTest.php
@@ -6,6 +6,7 @@ class ReaderTest extends \TestBase
     protected $mixedPath;
     protected $mixed;
     protected $single;
+    protected $empty;
 
     public function setUp()
     {
@@ -13,6 +14,8 @@ class ReaderTest extends \TestBase
         $single = FIXTURES . DS . 'results' . DS . 'single-wfailure.xml';
         $this->mixed = new Reader($this->mixedPath);
         $this->single = new Reader($single);
+        $empty = FIXTURES . DS . 'results' . DS . 'empty-test-suite.xml';
+        $this->empty = new Reader($empty);
     }
 
     /**
@@ -143,6 +146,21 @@ class ReaderTest extends \TestBase
         $failure = $case->failures[0];
         $this->assertEquals('PHPUnit_Framework_ExpectationFailedException', $failure['type']);
         $this->assertEquals("UnitTestWithMethodAnnotationsTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18", $failure['text']);
+    }
+
+    public function testEmptySuiteConstructsTestCase()
+    {
+        $suites = $this->empty->getSuites();
+        $this->assertEquals(1, sizeof($suites));
+
+        $suite = $suites[0];
+        $this->assertEquals('', $suite->name);
+        $this->assertEquals('', $suite->file);
+        $this->assertEquals(0, $suite->tests);
+        $this->assertEquals(0, $suite->assertions);
+        $this->assertEquals(0, $suite->failures);
+        $this->assertEquals(0, $suite->errors);
+        $this->assertEquals(0, $suite->time);
     }
 
     public function testMixedGetTotals()

--- a/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
@@ -282,16 +282,6 @@ class ResultPrinterTest extends ResultTester
 
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testEmptyResultsLog(){
-        $suite = new Suite('/path/to/ResultSuite.php', array());
-        $empty = FIXTURES . DS . 'results' . DS . 'empty-test-suite.xml';
-        file_put_contents($suite->getTempFile(), file_get_contents($empty));
-        $this->printer->printFeedback($suite);
-    }
-
     protected function getStartOutput(Options $options)
     {
         ob_start();


### PR DESCRIPTION
This fixes #164 and #146 

There are several bugfix proposals, none of them has been accepted so far. This approach is different and allows empty result files to be accepted, no matter what. Seems to be fine, according to tests. In case an empty result is processed, zero and empty values are accumulated, so results should not be affected. Overall count of suites is increased, but this is true, even if no tests are executed from these suites.

Please feel free to leave comments.