### PR TITLE
Fix Failing Build (Expected Exit Code)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "brianium/paratest",
     "require": {
         "php": ">=5.5.11",
-        "phpunit/phpunit": ">=3.7.8",
+        "phpunit/phpunit": "~5.0",
         "phpunit/php-timer": ">=1.0.4",
         "symfony/console": "~2.3|~3.0",
         "symfony/process": "~2.3|~3.0",

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -203,12 +203,17 @@ class PHPUnitTest extends FunctionalTestBase
         $this->assertEquals(2, $proc->getExitCode());
     }
 
-    public function testRunWithFatalParseErrorsHasExitCode255()
+    /**
+     * Paratest itself will throw a catchable exception while parsing the unit test before even opening a process and
+     * running it. In some PHP/library versions, the exception code would be 255. Otherwise, the exception code was 0
+     * and is manually converted to 1 inside the Symfony Console runner.
+     */
+    public function testRunWithFatalParseErrorsHasExitCode255or1()
     {
         $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalParseErrorTest.php', array(
             'bootstrap' => BOOTSTRAP
         ));
-        $this->assertEquals(255, $proc->getExitCode());
+        $this->assertTrue(in_array($proc->getExitCode(), [1, 255], true));
     }
 
     public function testRunWithFatalRuntimeErrorsHasExitCode1()


### PR DESCRIPTION
# What

**1.** Trying to get this repo back in line. I think it's time to require phpunit 5.0+ (while not yet using PHPUnit 6.0 due to the namespace changes). I think this means dropping support for 5.3 as well. Composer.json has been updated.

**2.** The [testRunWithFatalParseErrorsHasExitCode255](https://travis-ci.org/brianium/paratest/jobs/172151038) test was failing on PHP 7.0 due to some change in either PHP itself, or some dependency that has changed. What it comes down to I think is that PHP 7.0 changed some fatals to exceptions, and symfony console made some changes accordingly to reflect this (?). `1` is still a "bad" exit code so it should be fine to check for either 255 or 1... but open to hearing opinions.
