### PR TITLE
Add support to specify just the folder as config

### DIFF
--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -117,8 +117,28 @@ class PHPUnit extends Tester
     {
         $cwd = getcwd() . DIRECTORY_SEPARATOR;
 
-        if ($input->getOption('configuration')) {
+        if ($config = $input->getOption('configuration')) {
+          // Make it possible to not specify the exact location but rather just
+          // the folder.
+          if (\is_dir($config)) {
+            $configurationFile = $config . '/phpunit.xml';
+            if (\file_exists($configurationFile)) {
+              $configFilename = \realpath(
+                $configurationFile
+              );
+            }
+            elseif (\file_exists($configurationFile . '.dist')) {
+              $configFilename = \realpath(
+                $configurationFile . '.dist'
+              );
+            }
+            else {
+              throw new \InvalidArgumentException('No configuration file found in the specified directory.');
+            }
+          }
+          else {
             $configFilename = $input->getOption('configuration');
+          }
         } elseif (file_exists($cwd . 'phpunit.xml.dist')) {
             $configFilename = $cwd . 'phpunit.xml.dist';
         } elseif (file_exists($cwd . 'phpunit.xml')) {


### PR DESCRIPTION
Phpunit itself allows you to specify just the folder, see https://github.com/sebastianbergmann/phpunit/blob/master/src/TextUI/Command.php#L686 which is really nice when you mostly run unit tests, but want to be able to specify some environment variables.