### PR TITLE
Create a release compatible with phpunit 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ sudo: false
 
 dist: trusty
 
+# hhvm won't work with phpunit 6.x due to lack of Throwable support, see https://github.com/facebook/hhvm/issues/6037
 php:
     - 7.0
     - 7.1
-    - hhvm
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 dist: trusty
 
 php:
-    - 5.6
     - 7.0
     - 7.1
     - hhvm
@@ -17,18 +16,9 @@ cache:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: PHPUNIT_VERSION='3.7.*@stable'
-    - env: PHPUNIT_VERSION='4.*@stable'
-    - env: PHPUNIT_VERSION='6.*@stable'
     - env: PHPUNIT_VERSION='*@dev'
-  exclude:
-    - php: 5.5
-      env: PHPUNIT_VERSION='5.*@stable'
 
 env:
-    - PHPUNIT_VERSION='3.7.*@stable'
-    - PHPUNIT_VERSION='4.*@stable'
-    - PHPUNIT_VERSION='5.7.*@stable'
     - PHPUNIT_VERSION='6.*@stable'
     - PHPUNIT_VERSION='*@dev'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - env: PHPUNIT_VERSION='*@dev'
 
 env:
+    - PHPUNIT_VERSION='6.0.*@stable'
     - PHPUNIT_VERSION='6.*@stable'
     - PHPUNIT_VERSION='*@dev'
 

--- a/bin/phpunit-wrapper
+++ b/bin/phpunit-wrapper
@@ -33,6 +33,6 @@ while (true) {
     }
     $_SERVER['argv'] = $arguments[1];
 
-    $lastExitCode = PHPUnit_TextUI_Command::main(false);
+    $lastExitCode = PHPUnit\TextUI\Command::main(false);
     echo "FINISHED\n";
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "brianium/paratest",
     "require": {
         "php": ">=7.0",
-        "phpunit/phpunit": "~6.0.0",
+        "phpunit/phpunit": "~6.0",
         "phpunit/php-timer": ">=1.0.4",
         "symfony/console": "~2.3|~3.0",
         "symfony/process": "~2.3|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "brianium/paratest",
     "require": {
-        "php": ">=5.5.11",
-        "phpunit/phpunit": "~5.0",
+        "php": ">=7.0",
+        "phpunit/phpunit": "~6.0.0",
         "phpunit/php-timer": ">=1.0.4",
         "symfony/console": "~2.3|~3.0",
         "symfony/process": "~2.3|~3.0",

--- a/src/ParaTest/Console/Commands/ParaTestCommand.php
+++ b/src/ParaTest/Console/Commands/ParaTestCommand.php
@@ -26,7 +26,7 @@ class ParaTestCommand extends Command
      */
     public static function isWhitelistSupported()
     {
-        return Comparator::greaterThanOrEqualTo(\PHPUnit_Runner_Version::id(), '5.0.0');
+        return Comparator::greaterThanOrEqualTo(\PHPUnit\Runner\Version::id(), '5.0.0');
     }
 
     /**

--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -34,6 +34,7 @@ class Reader extends MetaProvider
                                            'assertions' => 0,
                                            'failures' => 0,
                                            'errors' => 0,
+                                           'skipped' => 0,
                                            'time' => 0);
 
     public function __construct($logFile)
@@ -79,6 +80,7 @@ class Reader extends MetaProvider
      * logs do not contain skipped or incomplete
      * tests this array will contain any number of the following
      * characters: .,F,E
+     * TODO: Update this, skipped was added in phpunit
      *
      * @return array
      */
@@ -92,6 +94,8 @@ class Reader extends MetaProvider
                     $feedback[] = 'F';
                 } elseif ($case->errors) {
                     $feedback[] = 'E';
+                } elseif ($case->skipped) {
+                    $feedback[] = 'S';
                 } else {
                     $feedback[] = '.';
                 }
@@ -167,6 +171,7 @@ class Reader extends MetaProvider
             $result['assertions'] += (int)$c['assertions'];
             $result['failures'] += sizeof($c->xpath('failure'));
             $result['errors'] += sizeof($c->xpath('error'));
+            $result['skipped'] += sizeof($c->xpath('skipped'));
             $result['time'] += floatval($c['time']);
             return $result;
         }, static::$defaultSuite);

--- a/src/ParaTest/Logging/JUnit/TestCase.php
+++ b/src/ParaTest/Logging/JUnit/TestCase.php
@@ -51,10 +51,13 @@ class TestCase
 
     /**
      * Number of errors in this test case
+     * TODO: Not a number?
      *
      * @var array
      */
     public $errors = array();
+
+    public $skipped = array();
 
     public function __construct(
         $name,

--- a/src/ParaTest/Logging/JUnit/TestCase.php
+++ b/src/ParaTest/Logging/JUnit/TestCase.php
@@ -94,6 +94,15 @@ class TestCase
     }
 
     /**
+     * @param string $type
+     * @param string $text
+     */
+    public function addSkipped($type, $text)
+    {
+        $this->addDefect('skipped', $type, $text);
+    }
+
+    /**
      * Add a defect type (error or failure)
      *
      * @param string $collName the name of the collection to add to
@@ -149,14 +158,20 @@ class TestCase
 
         $node       = self::addSystemOut($node);
         $failures   = $node->xpath('failure');
+        $skipped    = $node->xpath('skipped');
         $errors     = $node->xpath('error');
 
+        // TODO: each will be deprecated in 7.2, change to foreach
         while (list( , $fail) = each($failures)) {
             $case->addFailure((string)$fail['type'], (string)$fail);
         }
 
         while (list( , $err) = each($errors)) {
             $case->addError((string)$err['type'], (string)$err);
+        }
+
+        while (list( , $err) = each($skipped)) {
+            $case->addSkipped((string)$err['type'], (string)$err);
         }
 
         return $case;

--- a/src/ParaTest/Logging/JUnit/TestSuite.php
+++ b/src/ParaTest/Logging/JUnit/TestSuite.php
@@ -80,6 +80,7 @@ class TestSuite
         $this->tests = $tests;
         $this->assertions = $assertions;
         $this->failures = $failures;
+        $this->skipped = $skipped;
         $this->errors = $errors;
         $this->time = $time;
         $this->file = $file;

--- a/src/ParaTest/Logging/JUnit/TestSuite.php
+++ b/src/ParaTest/Logging/JUnit/TestSuite.php
@@ -38,6 +38,11 @@ class TestSuite
     public $errors;
 
     /**
+     * @var int
+     */
+    public $skipped;
+
+    /**
      * @var string
      */
     public $time;
@@ -67,6 +72,7 @@ class TestSuite
         $assertions,
         $failures,
         $errors,
+        $skipped,
         $time,
         $file = null
     ) {
@@ -94,6 +100,7 @@ class TestSuite
             $arr['assertions'],
             $arr['failures'],
             $arr['errors'],
+            $arr['skipped'],
             $arr['time'],
             $arr['file']
         );
@@ -113,6 +120,7 @@ class TestSuite
             (string) $node['assertions'],
             (string) $node['failures'],
             (string) $node['errors'],
+            (string) $node['skipped'],
             (string) $node['time'],
             (string) $node['file']
         );

--- a/src/ParaTest/Logging/JUnit/Writer.php
+++ b/src/ParaTest/Logging/JUnit/Writer.php
@@ -47,6 +47,7 @@ class Writer
                                         'tests' => 0,
                                         'assertions' => 0,
                                         'failures' => 0,
+                                        'skipped' => 0,
                                         'errors' => 0,
                                         'time' => 0
                                     );
@@ -196,6 +197,7 @@ class Writer
             $result['tests'] += $suite->tests;
             $result['assertions'] += $suite->assertions;
             $result['failures'] += $suite->failures;
+            $result['skipped'] += $suite->skipped;
             $result['errors'] += $suite->errors;
             $result['time'] += $suite->time;
             return $result;

--- a/src/ParaTest/Logging/LogInterpreter.php
+++ b/src/ParaTest/Logging/LogInterpreter.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 namespace ParaTest\Logging;
 
 use ParaTest\Logging\JUnit\Reader;
@@ -112,7 +112,7 @@ class LogInterpreter extends MetaProvider
         $dict = array();
         foreach ($this->getCases() as $case) {
             if (!isset($dict[$case->file])) {
-                $dict[$case->file] = new TestSuite($case->class, 0, 0, 0, 0, 0);
+                $dict[$case->file] = new TestSuite($case->class, 0, 0, 0, 0, 0, 0);
             }
             $dict[$case->file]->cases[] = $case;
             $dict[$case->file]->tests += 1;

--- a/src/ParaTest/Logging/LogInterpreter.php
+++ b/src/ParaTest/Logging/LogInterpreter.php
@@ -50,6 +50,7 @@ class LogInterpreter extends MetaProvider
     /**
      * Returns true if total errors and failures
      * equals 0, false otherwise
+     * TODO: Remove this comment if we don't care about skipped tests in callers
      *
      * @return bool
      */
@@ -119,6 +120,7 @@ class LogInterpreter extends MetaProvider
             $dict[$case->file]->assertions += $case->assertions;
             $dict[$case->file]->failures += sizeof($case->failures);
             $dict[$case->file]->errors += sizeof($case->errors);
+            $dict[$case->file]->skipped += sizeof($case->skipped);
             $dict[$case->file]->time += $case->time;
             $dict[$case->file]->file = $case->file;
         }

--- a/src/ParaTest/Parser/Parser.php
+++ b/src/ParaTest/Parser/Parser.php
@@ -133,7 +133,7 @@ class Parser
         foreach ($classes as $className) {
             $class = new \ReflectionClass($className);
             if ($class->getFileName() == $filename) {
-                if ($class->isSubclassOf('PHPUnit_Framework_TestCase')) {
+                if ($class->isSubclassOf('PHPUnit\Framework\TestCase')) {
                     if ($this->classNameMatchesFileName($filename, $className)) {
                         return $className;
                     } else if ($matchingClassName === null) {

--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -306,6 +306,9 @@ class ResultPrinter
 
         foreach ($feedbackItems as $item) {
             $this->printFeedbackItem($item);
+            if ($item === 'S')  {
+                $this->totalSkippedOrIncomplete++;
+            }
         }
 
         if ($this->processSkipped) {

--- a/src/ParaTest/Runners/PHPUnit/WrapperRunner.php
+++ b/src/ParaTest/Runners/PHPUnit/WrapperRunner.php
@@ -63,7 +63,7 @@ class WrapperRunner extends BaseRunner
     {
         $phpunit = $this->options->phpunit;
         $phpunitOptions = $this->options->filtered;
-        $phpunitOptions['no-globals-backup'] = null;
+        // $phpunitOptions['no-globals-backup'] = null;  // removed in phpunit 6.0
         while (count($this->pending)) {
             $this->waitForStreamsToChange($this->streams);
             foreach ($this->progressedWorkers() as $worker) {

--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -2,7 +2,7 @@
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 
-class TestBase extends PHPUnit_Framework_TestCase
+class TestBase extends PHPUnit\Framework\TestCase
 {
     /**
      * Get PHPUnit version
@@ -11,10 +11,10 @@ class TestBase extends PHPUnit_Framework_TestCase
      */
     protected static function getPhpUnitVersion()
     {
-        if (method_exists('\\PHPUnit_Runner_Version', 'id')) {
-            return \PHPUnit_Runner_Version::id();
+        if (method_exists('\\PHPUnit\\Runner\\Version', 'id')) {
+            return \PHPUnit\Runner\Version::id();
         }
-        return \PHPUnit_Runner_Version::VERSION;
+        return \PHPUnit\Runner\Version::VERSION;
     }
 
     protected function fixture($fixture)
@@ -108,7 +108,7 @@ class TestBase extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @throws \PHPUnit_Framework_SkippedTestError When code coverage library is not found
+     * @throws \PHPUnit\Framework\SkippedTestError When code coverage library is not found
      */
     protected static function skipIfCodeCoverageNotEnabled()
     {

--- a/test/fixtures/dataprovider-tests/DataProviderTest.php
+++ b/test/fixtures/dataprovider-tests/DataProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class DataProviderTest extends \PHPUnit_Framework_TestCase
+class DataProviderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider dataProviderNumeric50

--- a/test/fixtures/excluded-tests/PassingTest.php
+++ b/test/fixtures/excluded-tests/PassingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class PassingTest extends PHPUnit_FrameWork_TestCase
+class PassingTest extends PHPUnit\FrameWork\TestCase
 {
     public function testTruth()
     {

--- a/test/fixtures/excluded-tests/excluded/ExcludedFailingTest.php
+++ b/test/fixtures/excluded-tests/excluded/ExcludedFailingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ExcludedFailingTest extends PHPUnit_FrameWork_TestCase
+class ExcludedFailingTest extends PHPUnit\FrameWork\TestCase
 {
     public function testFail()
     {

--- a/test/fixtures/excluded-tests/included/IncludedPassingTest.php
+++ b/test/fixtures/excluded-tests/included/IncludedPassingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class IncludedPassingTest extends PHPUnit_FrameWork_TestCase
+class IncludedPassingTest extends PHPUnit\FrameWork\TestCase
 {
     public function testTruth()
     {

--- a/test/fixtures/failing-tests/AnonymousClass.inc
+++ b/test/fixtures/failing-tests/AnonymousClass.inc
@@ -1,6 +1,6 @@
 <?php
 
-new class() extends PHPUnit_Framework_TestCase {
+new class() extends PHPUnit\Framework\TestCase {
     /**
      * @return class
      */

--- a/test/fixtures/failing-tests/FailingTest.php
+++ b/test/fixtures/failing-tests/FailingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class FailingTest extends \PHPUnit_Framework_TestCase
+class FailingTest extends \PHPUnit\Framework\TestCase
 {
     public function testInvalidLogic()
     {

--- a/test/fixtures/failing-tests/StopOnFailureTest.php
+++ b/test/fixtures/failing-tests/StopOnFailureTest.php
@@ -1,5 +1,5 @@
 <?php
-class StopOnFailureTest extends PHPUnit_Framework_TestCase
+class StopOnFailureTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/failing-tests/UnitTestWithClassAnnotationTest.php
+++ b/test/fixtures/failing-tests/UnitTestWithClassAnnotationTest.php
@@ -4,7 +4,7 @@
  * @runParallel
  * @pizzaBox
  */
-class UnitTestWithClassAnnotationTest extends \PHPUnit_Framework_TestCase
+class UnitTestWithClassAnnotationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/failing-tests/UnitTestWithMethodAnnotationsTest.php
+++ b/test/fixtures/failing-tests/UnitTestWithMethodAnnotationsTest.php
@@ -1,5 +1,5 @@
 <?php
-class UnitTestWithMethodAnnotationsTest extends PHPUnit_Framework_TestCase
+class UnitTestWithMethodAnnotationsTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/globbing-support-tests/some-dir/TestTokenTest.php
+++ b/test/fixtures/globbing-support-tests/some-dir/TestTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SampleTest extends PHPUnit_FrameWork_TestCase
+class SampleTest extends PHPUnit\FrameWork\TestCase
 {
     public function testCase()
     {

--- a/test/fixtures/globbing-support-tests/some-dir2/TestTokenTest.php
+++ b/test/fixtures/globbing-support-tests/some-dir2/TestTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SecondSampleTest extends PHPUnit_FrameWork_TestCase
+class SecondSampleTest extends PHPUnit\FrameWork\TestCase
 {
     public function testCase()
     {

--- a/test/fixtures/paratest-only-tests/EnvironmentTest.php
+++ b/test/fixtures/paratest-only-tests/EnvironmentTest.php
@@ -1,5 +1,5 @@
 <?php
-class EnvironmentTest extends PHPUnit_Framework_TestCase
+class EnvironmentTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/paratest-only-tests/TestTokenTest.php
+++ b/test/fixtures/paratest-only-tests/TestTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class TestTokenTest extends PHPUnit_FrameWork_TestCase
+class TestTokenTest extends PHPUnit\FrameWork\TestCase
 {
     public function testThereIsAToken()
     {

--- a/test/fixtures/passing-tests/DependsOnChain.php
+++ b/test/fixtures/passing-tests/DependsOnChain.php
@@ -1,6 +1,6 @@
 <?php
 
-class DependsOnChain extends PHPUnit_Framework_TestCase
+class DependsOnChain extends PHPUnit\Framework\TestCase
 {
 
     public function testOneA()

--- a/test/fixtures/passing-tests/DependsOnSame.php
+++ b/test/fixtures/passing-tests/DependsOnSame.php
@@ -1,6 +1,6 @@
 <?php
 
-class DependsOnSame extends PHPUnit_Framework_TestCase
+class DependsOnSame extends PHPUnit\Framework\TestCase
 {
     public function testOneA()
     {

--- a/test/fixtures/passing-tests/FunctionalModeEachTestCalledOnce.php
+++ b/test/fixtures/passing-tests/FunctionalModeEachTestCalledOnce.php
@@ -1,6 +1,6 @@
 <?php
 
-class FunctionalModeEachTestCalledOnce extends PHPUnit_Framework_TestCase
+class FunctionalModeEachTestCalledOnce extends PHPUnit\Framework\TestCase
 {
     public function testOne()
     {

--- a/test/fixtures/passing-tests/GroupsTest.php
+++ b/test/fixtures/passing-tests/GroupsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class GroupsTest extends PHPUnit_FrameWork_TestCase
+class GroupsTest extends PHPUnit\FrameWork\TestCase
 {
     /**
      * @group group1

--- a/test/fixtures/passing-tests/LegacyNamespaceTest.php
+++ b/test/fixtures/passing-tests/LegacyNamespaceTest.php
@@ -3,7 +3,7 @@
 /**
  * This exampletest ensures that legacy namespaces (non PSR-0) can be used.
  */
-class Tests_Fixtures_Tests_LegacyNamespaceTest extends PHPUnit_Framework_TestCase
+class Tests_Fixtures_Tests_LegacyNamespaceTest extends PHPUnit\Framework\TestCase
 {
     public function testAlwaysTrue()
     {

--- a/test/fixtures/passing-tests/PreviouslyLoadedTest.php
+++ b/test/fixtures/passing-tests/PreviouslyLoadedTest.php
@@ -1,5 +1,5 @@
 <?php
-class PreviouslyLoadedTest extends PHPUnit_Framework_TestCase
+class PreviouslyLoadedTest extends PHPUnit\Framework\TestCase
 {
     public function testRuns() {
         $this->assertTrue(true);

--- a/test/fixtures/passing-tests/TestOfUnits.php
+++ b/test/fixtures/passing-tests/TestOfUnits.php
@@ -1,6 +1,6 @@
 <?php
 
-class TestOfUnits extends PHPUnit_Framework_TestCase
+class TestOfUnits extends PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/passing-tests/level1/AnotherUnitTestInSubLevelTest.php
+++ b/test/fixtures/passing-tests/level1/AnotherUnitTestInSubLevelTest.php
@@ -1,5 +1,5 @@
 <?php
-class AnotherUnitTestInSubLevelTest extends PHPUnit_Framework_TestCase
+class AnotherUnitTestInSubLevelTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/passing-tests/level1/UnitTestInSubLevelTest.php
+++ b/test/fixtures/passing-tests/level1/UnitTestInSubLevelTest.php
@@ -4,7 +4,7 @@ namespace Sublevel;
 /**
  * @runParallel
  */
-class UnitTestInSubLevelTest extends \PHPUnit_Framework_TestCase
+class UnitTestInSubLevelTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/passing-tests/level1/level2/AnotherUnitTestInSubSubLevelTest.php
+++ b/test/fixtures/passing-tests/level1/level2/AnotherUnitTestInSubSubLevelTest.php
@@ -1,5 +1,5 @@
 <?php
-class AnotherUnitTestInSubSubLevelTest extends PHPUnit_Framework_TestCase
+class AnotherUnitTestInSubSubLevelTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/passing-tests/level1/level2/UnitTestInSubSubLevelTest.php
+++ b/test/fixtures/passing-tests/level1/level2/UnitTestInSubSubLevelTest.php
@@ -2,7 +2,7 @@
 /**
  * @runParallel
  */
-class UnitTestInSubSubLevelTest extends PHPUnit_Framework_TestCase
+class UnitTestInSubSubLevelTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/results/junit-example-result.xml
+++ b/test/fixtures/results/junit-example-result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-    <testsuite name="test/fixtures/tests/" tests="7" assertions="6" failures="2" errors="1" time="0.007625">
+    <testsuite name="test/fixtures/tests/" tests="7" skipped="0" assertions="6" failures="2" errors="1" time="0.007625">
         <testsuite name="UnitTestWithClassAnnotationTest" tests="3" assertions="3" failures="1" errors="0" time="0.006109" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php">
             <testcase name="testTruth" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="10" assertions="1" time="0.001760"/>
             <testcase name="testFalsehood" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="18" assertions="1" time="0.001195">

--- a/test/fixtures/results/junit-example-result.xml
+++ b/test/fixtures/results/junit-example-result.xml
@@ -4,7 +4,7 @@
         <testsuite name="UnitTestWithClassAnnotationTest" tests="3" assertions="3" failures="1" errors="0" time="0.006109" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php">
             <testcase name="testTruth" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="10" assertions="1" time="0.001760"/>
             <testcase name="testFalsehood" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="18" assertions="1" time="0.001195">
-                <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithClassAnnotationTest::testFalsehood
+                <failure type="PHPUnit\Framework\ExpectationFailedException">UnitTestWithClassAnnotationTest::testFalsehood
                     Failed asserting that true is false.
 
                     /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php:20
@@ -24,7 +24,7 @@
         <testsuite name="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" tests="3" assertions="3" failures="1" errors="0" time="0.001119">
             <testcase name="testTruth" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="7" assertions="1" time="0.000341"/>
             <testcase name="testFalsehood" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="" assertions="1" time="0.000402">
-                <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
+                <failure type="PHPUnit\Framework\ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
                     Failed asserting that true is false.
 
                     /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18

--- a/test/fixtures/results/mixed-results-with-system-out.xml
+++ b/test/fixtures/results/mixed-results-with-system-out.xml
@@ -4,7 +4,7 @@
     <testsuite name="UnitTestWithClassAnnotationTest" tests="3" assertions="3" failures="1" errors="0" time="0.006109" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php">
       <testcase name="testTruth" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="10" assertions="1" time="0.001760"/>
       <testcase name="testFalsehood" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="18" assertions="1" time="0.001195">
-        <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
+        <failure type="PHPUnit\Framework\ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
 Failed asserting that true is false.
 
 /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18
@@ -34,7 +34,7 @@ Exception: Error!!!
     <testsuite name="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" tests="3" assertions="3" failures="1" errors="0" time="0.001119">
       <testcase name="testTruth" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="7" assertions="1" time="0.000341"/>
       <testcase name="testFalsehood" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="16" assertions="1" time="0.000402">
-        <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
+        <failure type="PHPUnit\Framework\ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
 Failed asserting that true is false.
 
 /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18

--- a/test/fixtures/results/mixed-results-with-system-out.xml
+++ b/test/fixtures/results/mixed-results-with-system-out.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="test/fixtures/tests/" tests="7" assertions="6" failures="2" errors="1" time="0.007625">
+  <testsuite name="test/fixtures/tests/" tests="7" skipped="0" assertions="6" failures="2" errors="1" time="0.007625">
     <testsuite name="UnitTestWithClassAnnotationTest" tests="3" assertions="3" failures="1" errors="0" time="0.006109" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php">
       <testcase name="testTruth" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="10" assertions="1" time="0.001760"/>
       <testcase name="testFalsehood" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="18" assertions="1" time="0.001195">

--- a/test/fixtures/results/mixed-results.xml
+++ b/test/fixtures/results/mixed-results.xml
@@ -4,7 +4,7 @@
     <testsuite name="UnitTestWithClassAnnotationTest" tests="3" assertions="3" failures="1" errors="0" time="0.006109" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php">
       <testcase name="testTruth" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="10" assertions="1" time="0.001760"/>
       <testcase name="testFalsehood" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="18" assertions="1" time="0.001195">
-        <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithClassAnnotationTest::testFalsehood
+        <failure type="PHPUnit\Framework\ExpectationFailedException">UnitTestWithClassAnnotationTest::testFalsehood
 Failed asserting that true is false.
 
 /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php:20
@@ -24,7 +24,7 @@ Exception: Error!!!
     <testsuite name="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" tests="3" assertions="3" failures="1" errors="0" time="0.001119">
       <testcase name="testTruth" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="7" assertions="1" time="0.000341"/>
       <testcase name="testFalsehood" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="16" assertions="1" time="0.000402">
-        <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
+        <failure type="PHPUnit\Framework\ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
 Failed asserting that true is false.
 
 /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18

--- a/test/fixtures/results/mixed-results.xml
+++ b/test/fixtures/results/mixed-results.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="test/fixtures/tests/" tests="7" assertions="6" failures="2" errors="1" time="0.007625">
+  <testsuite name="test/fixtures/tests/" tests="7" skipped="0" assertions="6" failures="2" errors="1" time="0.007625">
     <testsuite name="UnitTestWithClassAnnotationTest" tests="3" assertions="3" failures="1" errors="0" time="0.006109" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php">
       <testcase name="testTruth" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="10" assertions="1" time="0.001760"/>
       <testcase name="testFalsehood" class="UnitTestWithClassAnnotationTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php" line="18" assertions="1" time="0.001195">

--- a/test/fixtures/results/single-wfailure.xml
+++ b/test/fixtures/results/single-wfailure.xml
@@ -3,7 +3,7 @@
   <testsuite name="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" tests="3" assertions="3" failures="1" errors="0" time="0.005895">
     <testcase name="testTruth" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="7" assertions="1" time="0.001632"/>
     <testcase name="testFalsehood" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" line="16" assertions="1" time="0.001157">
-      <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
+      <failure type="PHPUnit\Framework\ExpectationFailedException">UnitTestWithMethodAnnotationsTest::testFalsehood
 Failed asserting that true is false.
 
 /home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18

--- a/test/fixtures/skipped-tests/IncompleteTest.php
+++ b/test/fixtures/skipped-tests/IncompleteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class IncompleteTest extends \PHPUnit_Framework_TestCase
+class IncompleteTest extends \PHPUnit\Framework\TestCase
 {
     public function testIncomplete()
     {

--- a/test/fixtures/skipped-tests/SkippedAndIncompleteDataProviderTest.php
+++ b/test/fixtures/skipped-tests/SkippedAndIncompleteDataProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SkippedAndIncompleteDataProviderTest extends \PHPUnit_Framework_TestCase
+class SkippedAndIncompleteDataProviderTest extends \PHPUnit\Framework\TestCase
 {
     public function dataProviderNumeric100()
     {

--- a/test/fixtures/skipped-tests/SkippedOrIncompleteTest.php
+++ b/test/fixtures/skipped-tests/SkippedOrIncompleteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SkippedOrIncompleteTest extends \PHPUnit_Framework_TestCase
+class SkippedOrIncompleteTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @group skipped-group

--- a/test/fixtures/skipped-tests/SkippedTest.php
+++ b/test/fixtures/skipped-tests/SkippedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SkippedTest extends \PHPUnit_Framework_TestCase
+class SkippedTest extends \PHPUnit\Framework\TestCase
 {
     public function testSkipped()
     {

--- a/test/fixtures/slow-tests/LongRunningTest.php
+++ b/test/fixtures/slow-tests/LongRunningTest.php
@@ -1,5 +1,5 @@
 <?php
-class LongRunningTest extends PHPUnit_Framework_TestCase
+class LongRunningTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @group fixtures

--- a/test/fixtures/special-classes/MultiLineClassDeclarationWithDifferentFilenameThanClassnameTest.php
+++ b/test/fixtures/special-classes/MultiLineClassDeclarationWithDifferentFilenameThanClassnameTest.php
@@ -1,10 +1,9 @@
 <?php
 
 class MultiLineClassDeclarationTest
-    extends PHPUnit_Framework_TestCase
+    extends PHPUnit\Framework\TestCase
 {
     public function testRuns() {
         $this->assertTrue(true);
     }
 }
- 

--- a/test/fixtures/special-classes/NameDoesNotMatch.php
+++ b/test/fixtures/special-classes/NameDoesNotMatch.php
@@ -1,3 +1,3 @@
 <?php
 
-class ParserTestClassFallsBack extends PHPUnit_Framework_TestCase{}
+class ParserTestClassFallsBack extends PHPUnit\Framework\TestCase{}

--- a/test/fixtures/special-classes/SomeNamespace/ParserTestClass.php
+++ b/test/fixtures/special-classes/SomeNamespace/ParserTestClass.php
@@ -2,8 +2,8 @@
 namespace SomeNamespace;
 
 // Test that it gives the class matching the file name priority.
-class SomeOtherClass extends \PHPUnit_Framework_TestCase{}
+class SomeOtherClass extends \PHPUnit\Framework\TestCase{}
 
-class ParserTestClass extends \PHPUnit_Framework_TestCase{}
+class ParserTestClass extends \PHPUnit\Framework\TestCase{}
 
-class AnotherClass extends \PHPUnit_Framework_TestCase{}
+class AnotherClass extends \PHPUnit\Framework\TestCase{}

--- a/test/fixtures/warning-tests/AbstractTest.php
+++ b/test/fixtures/warning-tests/AbstractTest.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class AbstractTest extends PHPUnit_Framework_TestCase
+abstract class AbstractTest extends PHPUnit\Framework\TestCase
 {
     public function testTruth()
     {

--- a/test/fixtures/warning-tests/HasWarningsTest.php
+++ b/test/fixtures/warning-tests/HasWarningsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class HasWarningsTest extends PHPUnit_Framework_TestCase
+class HasWarningsTest extends PHPUnit\Framework\TestCase
 {
     public function testPassingTest()
     {

--- a/test/fixtures/wrapper-runner-exit-code-tests/ErrorTest.php
+++ b/test/fixtures/wrapper-runner-exit-code-tests/ErrorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ErrorTest extends \PHPUnit_Framework_TestCase
+class ErrorTest extends \PHPUnit\Framework\TestCase
 {
     public function testError()
     {

--- a/test/fixtures/wrapper-runner-exit-code-tests/FailureTest.php
+++ b/test/fixtures/wrapper-runner-exit-code-tests/FailureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class FailureTest extends \PHPUnit_Framework_TestCase
+class FailureTest extends \PHPUnit\Framework\TestCase
 {
     public function testFailure()
     {

--- a/test/fixtures/wrapper-runner-exit-code-tests/SuccessTest.php
+++ b/test/fixtures/wrapper-runner-exit-code-tests/SuccessTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SuccessTest extends \PHPUnit_Framework_TestCase
+class SuccessTest extends \PHPUnit\Framework\TestCase
 {
     public function testSuccess()
     {

--- a/test/functional/Coverage/CoverageReporterTest.php
+++ b/test/functional/Coverage/CoverageReporterTest.php
@@ -100,7 +100,7 @@ class CoverageReporterTest extends TestBase
 
         static::assertFileExists($target);
 
-        $reportXml = \PHPUnit_Util_XML::loadFile($target);
+        $reportXml = \PHPUnit\Util\XML::loadFile($target);
         static::assertInstanceOf('DomDocument', $reportXml, 'Incorrect clover report xml was generated');
     }
 

--- a/test/functional/FunctionalTestBase.php
+++ b/test/functional/FunctionalTestBase.php
@@ -3,7 +3,7 @@
 use \Habitat\Habitat;
 use \Symfony\Component\Process\Process;
 
-class FunctionalTestBase extends PHPUnit_Framework_TestCase
+class FunctionalTestBase extends PHPUnit\Framework\TestCase
 {
     protected function fixture($fixture)
     {

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -14,7 +14,7 @@ class PHPUnitWarningsTest extends FunctionalTestBase
 
         $output = $proc->getOutput();
 
-        if (version_compare(PHPUnit_Runner_Version::id(), '5.1.0', '>=')) {
+        if (version_compare(PHPUnit\Runner\Version::id(), '5.1.0', '>=')) {
             // PHPUnit 5.1+ Changed how it handles test warnings (not E_WARNINGS)
             $this->assertContains("Warnings", $output, "Test should output warnings");
             $this->assertEquals(0, $proc->getExitCode(), "Test suite should succeed with 0");

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -14,13 +14,11 @@ class PHPUnitWarningsTest extends FunctionalTestBase
 
         $output = $proc->getOutput();
 
-        if (version_compare(PHPUnit\Runner\Version::id(), '5.1.0', '>=')) {
-            // PHPUnit 5.1+ Changed how it handles test warnings (not E_WARNINGS)
-            $this->assertContains("Warnings", $output, "Test should output warnings");
-            $this->assertEquals(0, $proc->getExitCode(), "Test suite should succeed with 0");
-        } else {
-            // PHPUnit 4.8 and below failed the test suite if a test warning occurred
-            $this->assertEquals(1, $proc->getExitCode(), "Test suite should fail with 1");
-        }
+        $this->assertTrue(version_compare(PHPUnit\Runner\Version::id(), '6.0.0', '>='), 'Expected phpunit 6.0.0+');
+        // PHPUnit 5.1+ Changed how it handles test warnings (not E_WARNINGS)
+        // PHPUnit 6.0 changed it back to non-zero exit code : https://github.com/sebastianbergmann/phpunit/issues/2446
+        // TODO: Does this have any consequences for paratest?
+        $this->assertContains("Warnings", $output, "Test should output warnings");
+        $this->assertEquals(1, $proc->getExitCode(), "Test suite should succeed with 0");
     }
 }

--- a/test/functional/SkippedOrIncompleteTest.php
+++ b/test/functional/SkippedOrIncompleteTest.php
@@ -111,7 +111,7 @@ class SkippedOrIncompleteTest extends FunctionalTestBase
 
         $proc = $this->invoker->execute();
 
-        $expected = "OK (100 tests, 33 assertions)";
+        $expected = "OK, but incomplete, skipped, or risky tests!\nTests: 100, Assertions: 33, Incomplete: 67.";
         $this->assertContains($expected, $proc->getOutput());
     }
 

--- a/test/functional/SkippedOrIncompleteTest.php
+++ b/test/functional/SkippedOrIncompleteTest.php
@@ -90,6 +90,7 @@ class SkippedOrIncompleteTest extends FunctionalTestBase
 
         $proc = $this->invoker->execute();
 
+        // TODO: What happened to the incomplete test?
         $expected = "OK, but incomplete, skipped, or risky tests!\n"
                   . "Tests: 1, Assertions: 0, Incomplete: 1.";
         $this->assertContains($expected, $proc->getOutput());
@@ -98,6 +99,7 @@ class SkippedOrIncompleteTest extends FunctionalTestBase
 
     public function testDataProviderWithSkippedInDefaultMode()
     {
+        // TODO: update comments
         // amount of tests is known, but based on amount of methods,
         // but test has more actual tests from data provider so
         // we can't identify skipped tests
@@ -109,7 +111,7 @@ class SkippedOrIncompleteTest extends FunctionalTestBase
 
         $proc = $this->invoker->execute();
 
-        $expected = "OK (33 tests, 33 assertions)";
+        $expected = "OK (100 tests, 33 assertions)";
         $this->assertContains($expected, $proc->getOutput());
     }
 

--- a/test/functional/TestGenerator.php
+++ b/test/functional/TestGenerator.php
@@ -26,7 +26,7 @@ class TestGenerator
 
     private function generateTestString($testName, $methods=1)
     {
-        $php = "<"."?php\n\nclass $testName extends PHPUnit_Framework_TestCase\n{\n";
+        $php = "<"."?php\n\nclass $testName extends PHPUnit\Framework\TestCase\n{\n";
 
         for($i=0; $i<$methods; $i++) {
             $php .= "\tpublic function testMethod{$i}(){";

--- a/test/functional/TestGenerator.php
+++ b/test/functional/TestGenerator.php
@@ -26,7 +26,7 @@ class TestGenerator
 
     private function generateTestString($testName, $methods=1)
     {
-        $php = "<"."?php\n\nclass $testName extends PHPUnit\Framework\TestCase\n{\n";
+        $php = "<"."?php\n\nclass $testName extends PHPUnit\\Framework\\TestCase\n{\n";
 
         for($i=0; $i<$methods; $i++) {
             $php .= "\tpublic function testMethod{$i}(){";

--- a/test/unit/ParaTest/Logging/JUnit/ReaderTest.php
+++ b/test/unit/ParaTest/Logging/JUnit/ReaderTest.php
@@ -87,7 +87,7 @@ class ReaderTest extends \TestBase
         $case = $suites[0]->suites[0]->cases[1];
         $this->assertEquals(1, sizeof($case->failures));
         $failure = $case->failures[0];
-        $this->assertEquals('PHPUnit_Framework_ExpectationFailedException', $failure['type']);
+        $this->assertEquals('PHPUnit\\Framework\\ExpectationFailedException', $failure['type']);
         $this->assertEquals("UnitTestWithClassAnnotationTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php:20", $failure['text']);
     }
 
@@ -144,7 +144,7 @@ class ReaderTest extends \TestBase
         $case = $suites[0]->cases[1];
         $this->assertEquals(1, sizeof($case->failures));
         $failure = $case->failures[0];
-        $this->assertEquals('PHPUnit_Framework_ExpectationFailedException', $failure['type']);
+        $this->assertEquals('PHPUnit\\Framework\\ExpectationFailedException', $failure['type']);
         $this->assertEquals("UnitTestWithMethodAnnotationsTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18", $failure['text']);
     }
 

--- a/test/unit/ParaTest/Runners/PHPUnit/ConfigurationTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/ConfigurationTest.php
@@ -54,13 +54,13 @@ class ConfigurationTest extends \TestBase
         $this->assertInternalType('array', $unitSuite);
         $this->assertCount(1, $unitSuite);
         $unitSuitePath = $unitSuite[0];
-        $this->assertInstanceOf('ParaTest\Runners\PHPUnit\SuitePath', $unitSuitePath);
+        $this->assertInstanceOf('ParaTest\\Runners\\PHPUnit\\SuitePath', $unitSuitePath);
         $this->assertEquals($basePath . 'test' . DS . 'unit', $unitSuitePath->getPath());
         $functionalSuite = $suites["ParaTest Functional Tests"];
         $this->assertInternalType('array', $functionalSuite);
         $this->assertCount(1, $functionalSuite);
         $functionalSuitePath = $functionalSuite[0];
-        $this->assertInstanceOf('ParaTest\Runners\PHPUnit\SuitePath', $functionalSuitePath);
+        $this->assertInstanceOf('ParaTest\\Runners\\PHPUnit\\SuitePath', $functionalSuitePath);
         $this->assertEquals($basePath . 'test' . DS . 'functional', $functionalSuitePath->getPath());
     }
 

--- a/test/unit/ParaTest/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/SuiteLoaderTest.php
@@ -55,7 +55,7 @@ class SuiteLoaderTest extends \TestBase
         $this->assertEquals($expected, sizeof($files));
     }
 
-    public function testLoadTestsuiteFilesFromConfigWhileIgnoringExcludeTag() 
+    public function testLoadTestsuiteFilesFromConfigWhileIgnoringExcludeTag()
     {
         $options = new Options(
             array('configuration' => $this->fixture('phpunit-excluded-including-file.xml'), 'testsuite' => 'ParaTest Fixtures')
@@ -68,7 +68,7 @@ class SuiteLoaderTest extends \TestBase
         $this->assertEquals($expected, sizeof($files));
     }
 
-    public function testLoadTestsuiteFilesFromDirFromConfigWhileRespectingExcludeTag() 
+    public function testLoadTestsuiteFilesFromDirFromConfigWhileRespectingExcludeTag()
     {
         $options = new Options(
             array('configuration' => $this->fixture('phpunit-excluded-including-dir.xml'), 'testsuite' => 'ParaTest Fixtures')
@@ -81,7 +81,7 @@ class SuiteLoaderTest extends \TestBase
         $this->assertEquals($expected, sizeof($files));
     }
 
-    public function testLoadTestsuiteFilesFromConfigWhileIncludingAndExcludingTheSameDirectory() 
+    public function testLoadTestsuiteFilesFromConfigWhileIncludingAndExcludingTheSameDirectory()
     {
         $options = new Options(
             array('configuration' => $this->fixture('phpunit-excluded-including-excluding-same-dir.xml'), 'testsuite' => 'ParaTest Fixtures')
@@ -290,6 +290,7 @@ class SuiteLoaderTest extends \TestBase
         $loader = new SuiteLoader();
         $fileWithoutClass = $this->fixture('special-classes/FileWithoutClass.php');
         $loader->load($fileWithoutClass);
+        $this->assertSame(0, count($loader->getTestMethods()));
     }
 
     public function testExecutableTestsForFunctionalModeUse()


### PR DESCRIPTION
I'd suggest bumping the major version to prevent accidental upgrades: The xml format is slightly different, phpunit removed deprecated functionality (if phpunit were to be installed as an indirect dependency), classes are different and so on.

- Could theoretically use `class_alias` depending on php version, but don't see a need to do so. Again, the xml format this outputs would be slightly different
- Not sure if I fixed `skipped` in all of the places
- changed the default behavior
- Removed old php and phpunit versions from travis.yml. Thoughts about adding phpunit 6.0 and 6.x separately?
- Updated example XML (didn't matter to unit tests. There should be no leading `\` for `PHPUnit\`... in xml)

Resolves #226 
