### PR TITLE
Switch to ubuntu `trusty` beta, to continue hhvm CI support in ~0.14 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 php:
     - 5.6
     - 7.0


### PR DESCRIPTION
Seen in travis output:

> HHVM is no longer supported on Ubuntu Precise.
> Please consider using Trusty with `dist: trusty`.