### PR TITLE
Allow multiple classes in one phpunit test file.

### DIFF
--- a/test/fixtures/failing-tests/AnonymousClass.inc
+++ b/test/fixtures/failing-tests/AnonymousClass.inc
@@ -1,6 +1,6 @@
 <?php
 
-new class() {
+new class() extends PHPUnit_Framework_TestCase {
     /**
      * @return class
      */

--- a/test/fixtures/special-classes/NameDoesNotMatch.php
+++ b/test/fixtures/special-classes/NameDoesNotMatch.php
@@ -1,4 +1,3 @@
 <?php
 
-class ParserTestClassFallsBack{}
- 
+class ParserTestClassFallsBack extends PHPUnit_Framework_TestCase{}

--- a/test/fixtures/special-classes/SomeNamespace/ParserTestClass.php
+++ b/test/fixtures/special-classes/SomeNamespace/ParserTestClass.php
@@ -1,7 +1,9 @@
 <?php
 namespace SomeNamespace;
 
-class SomeOtherClass{}
+// Test that it gives the class matching the file name priority.
+class SomeOtherClass extends \PHPUnit_Framework_TestCase{}
 
-class ParserTestClass{}
- 
+class ParserTestClass extends \PHPUnit_Framework_TestCase{}
+
+class AnotherClass extends \PHPUnit_Framework_TestCase{}


### PR DESCRIPTION
PHPUnit can properly handle this case without crashing.
Paratest should as well.

Before, Paratest would assume that the first class in the for loop was a
TestCase instance, and sometimes fail.

In several files in a project I work on,
there are helper classes alongside the test file,
used only in that test file.

Update test cases to reflect the new behaviour, require them to be
subclasses of PHPUnit_Framework_TestClass

- Keep giving priority to classes following PSR-0 naming