### PR TITLE
Convert all PHP files to use short array syntax

### DIFF
--- a/src/ParaTest/Console/ParaTestApplication.php
+++ b/src/ParaTest/Console/ParaTestApplication.php
@@ -37,9 +37,9 @@ class ParaTestApplication extends Application
      */
     public function getDefinition()
     {
-        return new InputDefinition(array(
+        return new InputDefinition([
             new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display this help message.')
-        ));
+        ]);
     }
 
     /**

--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -147,7 +147,7 @@ class PHPUnit extends Tester
         }
 
         if ($path) {
-            $options = array_merge(array('path' => $path), $options);
+            $options = array_merge(['path' => $path], $options);
         }
 
         return $options;

--- a/src/ParaTest/Console/Testers/Tester.php
+++ b/src/ParaTest/Console/Testers/Tester.php
@@ -58,7 +58,7 @@ abstract class Tester
     protected function displayHelp(InputInterface $input, OutputInterface $output)
     {
         $help = $this->command->getApplication()->find('help');
-        $input = new ArrayInput(array('command_name' => 'paratest'));
+        $input = new ArrayInput(['command_name' => 'paratest']);
         $help->run($input, $output);
         exit(0);
     }

--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -18,7 +18,7 @@ class Reader extends MetaProvider
     /**
      * @var array
      */
-    protected $suites = array();
+    protected $suites = [];
 
     /**
      * @var string
@@ -28,14 +28,14 @@ class Reader extends MetaProvider
     /**
      * @var array
      */
-    protected static $defaultSuite = array('name' => '',
-                                           'file' => '',
-                                           'tests' => 0,
-                                           'assertions' => 0,
-                                           'failures' => 0,
-                                           'errors' => 0,
-                                           'skipped' => 0,
-                                           'time' => 0);
+    protected static $defaultSuite = ['name' => '',
+                                      'file' => '',
+                                      'tests' => 0,
+                                      'assertions' => 0,
+                                      'failures' => 0,
+                                      'errors' => 0,
+                                      'skipped' => 0,
+                                      'time' => 0];
 
     public function __construct($logFile)
     {
@@ -86,7 +86,7 @@ class Reader extends MetaProvider
      */
     public function getFeedback()
     {
-        $feedback = array();
+        $feedback = [];
         $suites = $this->isSingle ? $this->suites : $this->suites[0]->suites;
         foreach ($suites as $suite) {
             foreach ($suite->cases as $case) {
@@ -131,7 +131,7 @@ class Reader extends MetaProvider
      */
     protected function initSuiteFromCases($nodeArray)
     {
-        $testCases = array();
+        $testCases = [];
         $properties = $this->caseNodesToSuiteProperties($nodeArray, $testCases);
         if (!$this->isSingle) {
             $this->addSuite($properties, $testCases);
@@ -160,11 +160,11 @@ class Reader extends MetaProvider
      * @param array $testCases an array reference. Individual testcases will be placed here.
      * @return mixed
      */
-    protected function caseNodesToSuiteProperties($nodeArray, &$testCases = array())
+    protected function caseNodesToSuiteProperties($nodeArray, &$testCases = [])
     {
-        $cb = array('ParaTest\\Logging\\JUnit\\TestCase', 'caseFromNode');
+        $cb = ['ParaTest\\Logging\\JUnit\\TestCase', 'caseFromNode'];
         return array_reduce($nodeArray, function ($result, $c) use (&$testCases, $cb) {
-            $testCases[] = call_user_func_array($cb, array($c));
+            $testCases[] = call_user_func_array($cb, [$c]);
             $result['name'] = (string)$c['class'];
             $result['file'] = (string)$c['file'];
             $result['tests'] = $result['tests'] + 1;
@@ -186,11 +186,11 @@ class Reader extends MetaProvider
     protected function getCaseNodes()
     {
         $caseNodes = $this->xml->xpath('//testcase');
-        $cases = array();
+        $cases = [];
         while (list( , $node) = each($caseNodes)) {
             $case = $node;
             if (!isset($cases[(string)$node['file']])) {
-                $cases[(string)$node['file']] = array();
+                $cases[(string)$node['file']] = [];
             }
             $cases[(string)$node['file']][] = $node;
         }

--- a/src/ParaTest/Logging/JUnit/TestCase.php
+++ b/src/ParaTest/Logging/JUnit/TestCase.php
@@ -47,7 +47,7 @@ class TestCase
      *
      * @var array
      */
-    public $failures = array();
+    public $failures = [];
 
     /**
      * Number of errors in this test case
@@ -55,9 +55,9 @@ class TestCase
      *
      * @var array
      */
-    public $errors = array();
+    public $errors = [];
 
-    public $skipped = array();
+    public $skipped = [];
 
     public function __construct(
         $name,
@@ -111,10 +111,10 @@ class TestCase
      */
     protected function addDefect($collName, $type, $text)
     {
-        $this->{$collName}[] = array(
+        $this->{$collName}[] = [
             'type' => $type,
             'text' => trim($text)
-        );
+        ];
     }
 
     /**

--- a/src/ParaTest/Logging/JUnit/TestSuite.php
+++ b/src/ParaTest/Logging/JUnit/TestSuite.php
@@ -57,14 +57,14 @@ class TestSuite
      *
      * @var array
      */
-    public $suites = array();
+    public $suites = [];
 
     /**
      * Cases belonging to this suite
      *
      * @var array
      */
-    public $cases = array();
+    public $cases = [];
 
     public function __construct(
         $name,

--- a/src/ParaTest/Logging/JUnit/Writer.php
+++ b/src/ParaTest/Logging/JUnit/Writer.php
@@ -43,14 +43,14 @@ class Writer
      *
      * @var array
      */
-    protected static $defaultSuite = array(
+    protected static $defaultSuite = [
                                         'tests' => 0,
                                         'assertions' => 0,
                                         'failures' => 0,
                                         'skipped' => 0,
                                         'errors' => 0,
                                         'time' => 0
-                                    );
+                                    ];
 
     public function __construct(LogInterpreter $interpreter, $name = '')
     {
@@ -201,7 +201,7 @@ class Writer
             $result['errors'] += $suite->errors;
             $result['time'] += $suite->time;
             return $result;
-        }, array_merge(array('name' => $this->name), self::$defaultSuite));
+        }, array_merge(['name' => $this->name], self::$defaultSuite));
     }
 
     /**

--- a/src/ParaTest/Logging/LogInterpreter.php
+++ b/src/ParaTest/Logging/LogInterpreter.php
@@ -12,7 +12,7 @@ class LogInterpreter extends MetaProvider
      *
      * @var array
      */
-    protected $readers = array();
+    protected $readers = [];
 
     /**
      * Reset the array pointer of the internal
@@ -69,7 +69,7 @@ class LogInterpreter extends MetaProvider
      */
     public function getCases()
     {
-        $cases = array();
+        $cases = [];
         while (list( , $reader) = each($this->readers)) {
             foreach ($reader->getSuites() as $suite) {
                 $cases = array_merge($cases, $suite->cases);
@@ -110,7 +110,7 @@ class LogInterpreter extends MetaProvider
      */
     public function flattenCases()
     {
-        $dict = array();
+        $dict = [];
         foreach ($this->getCases() as $case) {
             if (!isset($dict[$case->file])) {
                 $dict[$case->file] = new TestSuite($case->class, 0, 0, 0, 0, 0, 0);
@@ -161,7 +161,7 @@ class LogInterpreter extends MetaProvider
      */
     private function mergeMessages($method)
     {
-        $messages = array();
+        $messages = [];
         foreach ($this->readers as $reader) {
             $messages = array_merge($messages, $reader->$method());
         }

--- a/src/ParaTest/Logging/MetaProvider.php
+++ b/src/ParaTest/Logging/MetaProvider.php
@@ -61,15 +61,15 @@ abstract class MetaProvider
      */
     protected function getMessages($type)
     {
-        $messages = array();
+        $messages = [];
         $suites = $this->isSingle ? $this->suites : $this->suites[0]->suites;
         foreach ($suites as $suite) {
             $messages = array_merge($messages, array_reduce($suite->cases, function ($result, $case) use ($type) {
                 return array_merge($result, array_reduce($case->$type, function ($msgs, $msg) {
                     $msgs[] = $msg['text'];
                     return $msgs;
-                }, array()));
-            }, array()));
+                }, []));
+            }, []));
         }
         return $messages;
     }

--- a/src/ParaTest/Parser/ParsedClass.php
+++ b/src/ParaTest/Parser/ParsedClass.php
@@ -16,7 +16,7 @@ class ParsedClass extends ParsedObject
      */
     private $methods;
 
-    public function __construct($doc, $name, $namespace, $methods = array())
+    public function __construct($doc, $name, $namespace, $methods = [])
     {
         parent::__construct($doc, $name);
         $this->namespace = $namespace;
@@ -31,7 +31,7 @@ class ParsedClass extends ParsedObject
      * @param array $annotations
      * @return array
      */
-    public function getMethods($annotations = array())
+    public function getMethods($annotations = [])
     {
         $methods = array_filter($this->methods, function ($m) use ($annotations) {
             foreach ($annotations as $a => $v) {

--- a/src/ParaTest/Parser/Parser.php
+++ b/src/ParaTest/Parser/Parser.php
@@ -85,7 +85,7 @@ class Parser
      */
     private function getMethods()
     {
-        $tests = array();
+        $tests = [];
         $methods = $this->refl->getMethods(\ReflectionMethod::IS_PUBLIC);
         foreach ($methods as $method) {
             $hasTestName = preg_match(self::$testName, $method->getName());

--- a/src/ParaTest/Runners/PHPUnit/BaseRunner.php
+++ b/src/ParaTest/Runners/PHPUnit/BaseRunner.php
@@ -31,7 +31,7 @@ abstract class BaseRunner
      *
      * @var array
      */
-    protected $pending = array();
+    protected $pending = [];
 
     /**
      * A collection of ExecutableTest objects that have processes
@@ -39,7 +39,7 @@ abstract class BaseRunner
      *
      * @var array
      */
-    protected $running = array();
+    protected $running = [];
 
     /**
      * A tallied exit code that returns the highest exit
@@ -57,7 +57,7 @@ abstract class BaseRunner
     protected $coverage = null;
 
 
-    public function __construct($opts = array())
+    public function __construct($opts = [])
     {
         $this->options = new Options($opts);
         $this->interpreter = new LogInterpreter();

--- a/src/ParaTest/Runners/PHPUnit/Configuration.php
+++ b/src/ParaTest/Runners/PHPUnit/Configuration.php
@@ -23,7 +23,7 @@ class Configuration
      */
     protected $xml;
 
-    protected $availableNodes = array('exclude', 'file', 'directory', 'testsuite');
+    protected $availableNodes = ['exclude', 'file', 'directory', 'testsuite'];
 
     /**
      * A collection of datastructures
@@ -32,7 +32,7 @@ class Configuration
      *
      * @var array
      */
-    protected $suites = array();
+    protected $suites = [];
 
     public function __construct($path)
     {
@@ -78,7 +78,7 @@ class Configuration
         if (!$this->xml) {
             return null;
         }
-        $suites = array();
+        $suites = [];
         $nodes  = $this->xml->xpath('//testsuites/testsuite');
 
         while (list(, $node) = each($nodes)) {
@@ -99,8 +99,8 @@ class Configuration
     {
         $nodes = $this->xml->xpath(sprintf('//testsuite[@name="%s"]', $suiteName));
 
-        $suites        = array();
-        $excludedPaths = array();
+        $suites        = [];
+        $excludedPaths = [];
         while (list(, $node) = each($nodes)) {
             foreach ($this->availableNodes as $nodeName) {
                 foreach ($node->{$nodeName} as $nodeContent) {
@@ -161,11 +161,11 @@ class Configuration
         $real = realpath($this->getConfigDir().$path);
 
         if ($real !== false) {
-            return array($real);
+            return [$real];
         }
 
         if ($this->isGlobRequired($path)) {
-            $paths = array();
+            $paths = [];
             foreach (glob($this->getConfigDir().$path, GLOB_ONLYDIR) as $path) {
                 if (($path = realpath($path)) !== false) {
                     $paths[] = $path;

--- a/src/ParaTest/Runners/PHPUnit/ExecutableTest.php
+++ b/src/ParaTest/Runners/PHPUnit/ExecutableTest.php
@@ -21,7 +21,7 @@ abstract class ExecutableTest
      */
     protected $temp;
     protected $fullyQualifiedClassName;
-    protected $pipes = array();
+    protected $pipes = [];
 
     /**
      * Path where the coveragereport is stored
@@ -178,7 +178,7 @@ abstract class ExecutableTest
      * @param array $environmentVariables
      * @return $this
      */
-    public function run($binary, $options = array(), $environmentVariables = array())
+    public function run($binary, $options = [], $environmentVariables = [])
     {
         $environmentVariables['PARATEST'] = 1;
         $this->handleEnvironmentVariables($environmentVariables);
@@ -207,9 +207,9 @@ abstract class ExecutableTest
      * @param  array  $options Command line options.
      * @return string          Command line.
      */
-    public function command($binary, $options = array())
+    public function command($binary, $options = [])
     {
-        $options = array_merge($this->prepareOptions($options), array('log-junit' => $this->getTempFile()));
+        $options = array_merge($this->prepareOptions($options), ['log-junit' => $this->getTempFile()]);
         $options = $this->redirectCoverageOption($options);
         return $this->getCommandString($binary, $options);
     }
@@ -293,7 +293,7 @@ abstract class ExecutableTest
      * @param array $options
      * @return mixed
      */
-    protected function getCommandString($binary, $options = array())
+    protected function getCommandString($binary, $options = [])
     {
         $builder = new ProcessBuilder();
         $builder->setPrefix($binary);

--- a/src/ParaTest/Runners/PHPUnit/Options.php
+++ b/src/ParaTest/Runners/PHPUnit/Options.php
@@ -63,9 +63,9 @@ class Options
      *
      * @var array
      */
-    protected $annotations = array();
+    protected $annotations = [];
 
-    public function __construct($opts = array())
+    public function __construct($opts = [])
     {
         foreach (self::defaults() as $opt => $value) {
             $opts[$opt] = isset($opts[$opt]) ? $opts[$opt] : $value;
@@ -90,10 +90,10 @@ class Options
         // to phpunit)
         $this->groups = isset($opts['group']) && $opts['group'] !== ""
                       ? explode(",", $opts['group'])
-                      : array();
+                      : [];
         $this->excludeGroups = isset($opts['exclude-group']) && $opts['exclude-group'] !== ""
                              ? explode(",", $opts['exclude-group'])
-                             : array();
+                             : [];
 
         if (strlen($opts['filter']) > 0 && !$this->functional) {
             throw new \RuntimeException("Option --filter is not implemented for non functional mode");
@@ -122,7 +122,7 @@ class Options
      */
     protected static function defaults()
     {
-        return array(
+        return [
             'processes' => 5,
             'path' => '',
             'phpunit' => static::phpunit(),
@@ -134,7 +134,7 @@ class Options
             'testsuite' => '',
             'max-batch-size' => 0,
             'filter' => null
-        );
+        ];
     }
 
     /**
@@ -185,7 +185,7 @@ class Options
      */
     protected function filterOptions($options)
     {
-        $filtered = array_diff_key($options, array(
+        $filtered = array_diff_key($options, [
             'processes' => $this->processes,
             'path' => $this->path,
             'phpunit' => $this->phpunit,
@@ -197,7 +197,7 @@ class Options
             'testsuite' => $this->testsuite,
             'max-batch-size' => $this->maxBatchSize,
             'filter' => $this->filter
-        ));
+        ]);
         if ($configuration = $this->getConfigurationPath($filtered)) {
             $filtered['configuration'] = new Configuration($configuration);
         }
@@ -235,7 +235,7 @@ class Options
         }
 
         $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        $suffixes = array('phpunit.xml', 'phpunit.xml.dist');
+        $suffixes = ['phpunit.xml', 'phpunit.xml.dist'];
 
         foreach ($suffixes as $suffix) {
             if ($this->isFile($path . $suffix)) {
@@ -251,7 +251,7 @@ class Options
      */
     protected function initAnnotations()
     {
-        $annotatedOptions = array('group');
+        $annotatedOptions = ['group'];
         foreach ($this->filtered as $key => $value) {
             if (array_search($key, $annotatedOptions) !== false) {
                 $this->annotations[$key] = $value;

--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -18,7 +18,7 @@ class ResultPrinter
      *
      * @var array
      */
-    protected $suites = array();
+    protected $suites = [];
 
     /**
      * @var \ParaTest\Logging\LogInterpreter
@@ -79,7 +79,7 @@ class ResultPrinter
      *
      * @var array
      */
-    protected $warnings = array();
+    protected $warnings = [];
 
     /**
      * Number of columns

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -11,10 +11,10 @@ class Runner extends BaseRunner
      *
      * @var array
      */
-    protected $tokens = array();
+    protected $tokens = [];
 
 
-    public function __construct($opts = array())
+    public function __construct($opts = [])
     {
         parent::__construct($opts);
         $this->initTokens();
@@ -70,7 +70,7 @@ class Runner extends BaseRunner
             $tokenData = $this->getNextAvailableToken();
             if ($tokenData !== false) {
                 $this->acquireToken($tokenData['token']);
-                $env = array('TEST_TOKEN' => $tokenData['token'], 'UNIQUE_TEST_TOKEN' => $tokenData['unique']) + Habitat::getAll();
+                $env = ['TEST_TOKEN' => $tokenData['token'], 'UNIQUE_TEST_TOKEN' => $tokenData['unique']] + Habitat::getAll();
                 $this->running[$tokenData['token']] = array_shift($this->pending)->run($opts->phpunit, $opts->filtered, $env);
             }
         }
@@ -94,7 +94,7 @@ class Runner extends BaseRunner
         $this->setExitCode($test);
         $test->stop();
         if ($this->options->stopOnFailure && $test->getExitCode() > 0) {
-            $this->pending = array();
+            $this->pending = [];
         }
         if (static::PHPUNIT_FATAL_ERROR === $test->getExitCode()) {
             $errorOutput = $test->getStderr();
@@ -132,9 +132,9 @@ class Runner extends BaseRunner
      */
     protected function initTokens()
     {
-        $this->tokens = array();
+        $this->tokens = [];
         for ($i = 0; $i < $this->options->processes; $i++) {
-            $this->tokens[$i] = array('token' => $i, 'unique' => uniqid($i), 'available' => true);
+            $this->tokens[$i] = ['token' => $i, 'unique' => uniqid($i), 'available' => true];
         }
     }
 

--- a/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
+++ b/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
@@ -13,14 +13,14 @@ class SuiteLoader
      *
      * @var array
      */
-    protected $files = array();
+    protected $files = [];
 
     /**
      * The collection of parsed test classes
      *
      * @var array
      */
-    protected $loadedSuites = array();
+    protected $loadedSuites = [];
 
     public function __construct($options = null)
     {
@@ -50,7 +50,7 @@ class SuiteLoader
      */
     public function getTestMethods()
     {
-        $methods = array();
+        $methods = [];
         foreach ($this->loadedSuites as $suite) {
             $methods = array_merge($methods, $suite->getFunctions());
         }
@@ -123,7 +123,7 @@ class SuiteLoader
 
     private function executableTests($path, $class)
     {
-        $executableTests = array();
+        $executableTests = [];
         $methodBatches = $this->getMethodBatches($class);
         foreach ($methodBatches as $methodBatch) {
             $executableTest = new TestMethod($path, $methodBatch);
@@ -143,9 +143,9 @@ class SuiteLoader
      */
     private function getMethodBatches($class)
     {
-        $classMethods = $class->getMethods($this->options ? $this->options->annotations : array());
+        $classMethods = $class->getMethods($this->options ? $this->options->annotations : []);
         $maxBatchSize = $this->options && $this->options->functional ? $this->options->maxBatchSize : 0;
-        $batches = array();
+        $batches = [];
         foreach ($classMethods as $method) {
             $tests = $this->getMethodTests($class, $method, $maxBatchSize != 0);
             // if filter passed to paratest then method tests can be blank if not match to filter
@@ -183,7 +183,7 @@ class SuiteLoader
             ) {
                 $batches[$lastIndex][] = $test;
             } else {
-                $batches[] = array($test);
+                $batches[] = [$test];
             }
         }
     }
@@ -201,7 +201,7 @@ class SuiteLoader
      */
     private function getMethodTests($class, $method, $useDataProvider = false)
     {
-        $result = array();
+        $result = [];
 
         $groups = $this->methodGroups($method);
 
@@ -209,7 +209,7 @@ class SuiteLoader
         if ($useDataProvider && isset($dataProvider)) {
             $testFullClassName = "\\" . $class->getName();
             $testClass = new $testFullClassName();
-            $result = array();
+            $result = [];
             $datasetKeys = array_keys($testClass->$dataProvider());
             foreach ($datasetKeys as $key) {
                 $test = sprintf(
@@ -222,7 +222,7 @@ class SuiteLoader
                 }
             }
         } elseif ($this->testMatchOptions($class->getName(), $method->getName(), $groups)) {
-            $result = array($method->getName());
+            $result = [$method->getName()];
         }
 
         return $result;
@@ -293,7 +293,7 @@ class SuiteLoader
         if (preg_match_all("/@\bgroup\b \b(.*)\b/", $method->getDocBlock(), $matches)) {
             return $matches[1];
         }
-        return array();
+        return [];
     }
 
     private function createSuite($path, ParsedClass $class)

--- a/src/ParaTest/Runners/PHPUnit/TestFileLoader.php
+++ b/src/ParaTest/Runners/PHPUnit/TestFileLoader.php
@@ -29,14 +29,14 @@ class TestFileLoader
      *
      * @var array
      */
-    protected $files = array();
+    protected $files = [];
 
     /**
      * The collection of excluded files
      *
      * @var array
      */
-    protected $excludedFiles = array();
+    protected $excludedFiles = [];
 
     /**
      * When true, the SuiteLoader add the files to excluded files
@@ -65,8 +65,8 @@ class TestFileLoader
     public function loadSuitePath(SuitePath $path)
     {
         // First initialize the list of files and excluded files
-        $this->files          = array();
-        $this->excludedFiles  = array();
+        $this->files          = [];
+        $this->excludedFiles  = [];
         $this->excludingFiles = true;
         foreach ($path->getExcludedPaths() as $excludedPath) {
             $this->loadPath($excludedPath, $path->getPattern());
@@ -77,7 +77,7 @@ class TestFileLoader
         $this->loadPath($path->getPath(), $path->getPattern());
 
         // Reinitialise the excluded files
-        $this->excludedFiles = array();
+        $this->excludedFiles = [];
 
         return $this->files;
     }
@@ -93,7 +93,7 @@ class TestFileLoader
      */
     public function loadPath($path, $pattern = null)
     {
-        $this->files = array();
+        $this->files = [];
         $path        = $path ?: $this->options->path;
         $pattern     = is_null($pattern) ? self::TEST_PATTERN : $pattern;
 

--- a/src/ParaTest/Runners/PHPUnit/Worker.php
+++ b/src/ParaTest/Runners/PHPUnit/Worker.php
@@ -5,17 +5,17 @@ use Exception;
 
 class Worker
 {
-    private static $descriptorspec = array(
-       0 => array("pipe", "r"),
-       1 => array("pipe", "w"),
-       2 => array("pipe", "w")
-    );
+    private static $descriptorspec = [
+       0 => ["pipe", "r"],
+       1 => ["pipe", "w"],
+       2 => ["pipe", "w"]
+    ];
     private $proc;
     private $pipes;
     private $inExecution = 0;
     private $isRunning = false;
     private $exitCode = null;
-    private $commands = array();
+    private $commands = [];
     private $chunks = '';
     private $alreadyReadOutput = '';
     /**
@@ -33,7 +33,7 @@ class Worker
             $bin .= "UNIQUE_TEST_TOKEN=$uniqueToken ";
         }
         $bin .= "exec \"$wrapperBinary\"";
-        $pipes = array();
+        $pipes = [];
         $this->proc = proc_open($bin, self::$descriptorspec, $pipes);
         $this->pipes = $pipes;
         $this->isRunning = true;

--- a/src/ParaTest/Runners/PHPUnit/WrapperRunner.php
+++ b/src/ParaTest/Runners/PHPUnit/WrapperRunner.php
@@ -103,8 +103,8 @@ class WrapperRunner extends BaseRunner
     // put on WorkersPool
     private function waitForStreamsToChange($modified)
     {
-        $write = array();
-        $except = array();
+        $write = [];
+        $except = [];
         $result = stream_select($modified, $write, $except, 1);
         if ($result === false) {
             throw new \RuntimeException("stream_select() returned an error while waiting for all workers to finish.");
@@ -119,7 +119,7 @@ class WrapperRunner extends BaseRunner
      */
     private function progressedWorkers()
     {
-        $result = array();
+        $result = [];
         foreach ($this->modified as $modifiedStream) {
             $found = null;
             foreach ($this->streams as $index => $stream) {
@@ -130,7 +130,7 @@ class WrapperRunner extends BaseRunner
             }
             $result[$found] = $this->workers[$found];
         }
-        $this->modified = array();
+        $this->modified = [];
         return $result;
     }
 
@@ -141,7 +141,7 @@ class WrapperRunner extends BaseRunner
      */
     private function streamsOf($workers)
     {
-        $streams = array();
+        $streams = [];
         foreach (array_keys($workers) as $index) {
             $streams[$index] = $this->streams[$index];
         }

--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -28,7 +28,7 @@ class TestBase extends PHPUnit\Framework\TestCase
 
     protected function findTests($dir)
     {
-        $files = array();
+        $files = [];
         foreach(new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($dir, \RecursiveIteratorIterator::SELF_FIRST)) as $file){
             if(preg_match('/Test\.php$/', $file)) $files []= $file;

--- a/test/fixtures/dataprovider-tests/DataProviderTest.php
+++ b/test/fixtures/dataprovider-tests/DataProviderTest.php
@@ -12,9 +12,9 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
 
     public function dataProviderNumeric50()
     {
-        $result = array();
+        $result = [];
         for ($i = 0; $i < 50; $i++) {
-            $result[] = array($i, $i);
+            $result[] = [$i, $i];
         }
 
         return $result;
@@ -30,10 +30,10 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
 
     public function dataProviderNamed50()
     {
-        $result = array();
+        $result = [];
         for ($i = 0; $i < 50; $i++) {
             $name = "name_of_test_" . $i;
-            $result[$name] = array($i, $i);
+            $result[$name] = [$i, $i];
         }
 
         return $result;
@@ -49,9 +49,9 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
 
     public function dataProviderNumeric1000()
     {
-        $result = array();
+        $result = [];
         for ($i = 0; $i < 1000; $i++) {
-            $result[] = array($i, $i);
+            $result[] = [$i, $i];
         }
 
         return $result;

--- a/test/fixtures/failing-tests/UnitTestWithClassAnnotationTest.php
+++ b/test/fixtures/failing-tests/UnitTestWithClassAnnotationTest.php
@@ -29,7 +29,7 @@ class UnitTestWithClassAnnotationTest extends \PHPUnit\Framework\TestCase
      */
     public function testArrayLength()
     {
-        $elems = array(1,2,3,4,5);
+        $elems = [1,2,3,4,5];
         $this->assertEquals(5, sizeof($elems));
     }
 

--- a/test/fixtures/failing-tests/UnitTestWithMethodAnnotationsTest.php
+++ b/test/fixtures/failing-tests/UnitTestWithMethodAnnotationsTest.php
@@ -22,7 +22,7 @@ class UnitTestWithMethodAnnotationsTest extends PHPUnit\Framework\TestCase
      */
     public function testArrayLength()
     {
-        $elems = array(1,2,3,4,5);
+        $elems = [1,2,3,4,5];
         $this->assertEquals(5, sizeof($elems));
     }
 }

--- a/test/fixtures/passing-tests/GroupsTest.php
+++ b/test/fixtures/passing-tests/GroupsTest.php
@@ -23,7 +23,7 @@ class GroupsTest extends PHPUnit\FrameWork\TestCase
      */
     public function testArrayLength()
     {
-        $values = array(1, 3, 4, 7);
+        $values = [1, 3, 4, 7];
         $this->assertEquals(4, count($values));
     }
 

--- a/test/fixtures/passing-tests/TestOfUnits.php
+++ b/test/fixtures/passing-tests/TestOfUnits.php
@@ -15,7 +15,7 @@ class TestOfUnits extends PHPUnit\Framework\TestCase
      */
     public function testArrayLength()
     {
-        $elems = array(1,2,3,4,5);
+        $elems = [1,2,3,4,5];
         $this->assertEquals(5, sizeof($elems));
     }
 }

--- a/test/fixtures/passing-tests/level1/AnotherUnitTestInSubLevelTest.php
+++ b/test/fixtures/passing-tests/level1/AnotherUnitTestInSubLevelTest.php
@@ -22,7 +22,7 @@ class AnotherUnitTestInSubLevelTest extends PHPUnit\Framework\TestCase
      */
     public function testArrayLength()
     {
-        $elems = array(1,2,3,4,5);
+        $elems = [1,2,3,4,5];
         $this->assertEquals(5, sizeof($elems));
     }
 }

--- a/test/fixtures/passing-tests/level1/UnitTestInSubLevelTest.php
+++ b/test/fixtures/passing-tests/level1/UnitTestInSubLevelTest.php
@@ -27,7 +27,7 @@ class UnitTestInSubLevelTest extends \PHPUnit\Framework\TestCase
      */
     public function testArrayLength()
     {
-        $elems = array(1,2,3,4,5);
+        $elems = [1,2,3,4,5];
         $this->assertEquals(5, sizeof($elems));
     }
 }

--- a/test/fixtures/passing-tests/level1/level2/AnotherUnitTestInSubSubLevelTest.php
+++ b/test/fixtures/passing-tests/level1/level2/AnotherUnitTestInSubSubLevelTest.php
@@ -22,7 +22,7 @@ class AnotherUnitTestInSubSubLevelTest extends PHPUnit\Framework\TestCase
      */
     public function testArrayLength()
     {
-        $elems = array(1,2,3,4,5);
+        $elems = [1,2,3,4,5];
         $this->assertEquals(5, sizeof($elems));
     }
 }

--- a/test/fixtures/passing-tests/level1/level2/UnitTestInSubSubLevelTest.php
+++ b/test/fixtures/passing-tests/level1/level2/UnitTestInSubSubLevelTest.php
@@ -25,7 +25,7 @@ class UnitTestInSubSubLevelTest extends PHPUnit\Framework\TestCase
      */
     public function testArrayLength()
     {
-        $elems = array(1,2,3,4,5);
+        $elems = [1,2,3,4,5];
         $this->assertEquals(5, sizeof($elems));
     }
 }

--- a/test/fixtures/skipped-tests/SkippedAndIncompleteDataProviderTest.php
+++ b/test/fixtures/skipped-tests/SkippedAndIncompleteDataProviderTest.php
@@ -4,9 +4,9 @@ class SkippedAndIncompleteDataProviderTest extends \PHPUnit\Framework\TestCase
 {
     public function dataProviderNumeric100()
     {
-        $result = array();
+        $result = [];
         for ($i = 0; $i < 100; $i++) {
-            $result[] = array($i, $i);
+            $result[] = [$i, $i];
         }
 
         return $result;

--- a/test/fixtures/skipped-tests/SkippedOrIncompleteTest.php
+++ b/test/fixtures/skipped-tests/SkippedOrIncompleteTest.php
@@ -20,9 +20,9 @@ class SkippedOrIncompleteTest extends \PHPUnit\Framework\TestCase
 
     public function dataProviderNumeric100()
     {
-        $result = array();
+        $result = [];
         for ($i = 0; $i < 100; $i++) {
-            $result[] = array($i, $i);
+            $result[] = [$i, $i];
         }
 
         return $result;

--- a/test/fixtures/slow-tests/LongRunningTest.php
+++ b/test/fixtures/slow-tests/LongRunningTest.php
@@ -25,7 +25,7 @@ class LongRunningTest extends PHPUnit\Framework\TestCase
     public function testThree()
     {
         sleep(5);
-        $elems = array(1,2,3,4,5);
+        $elems = [1,2,3,4,5];
         $this->assertEquals(5, sizeof($elems));
     }
 }

--- a/test/functional/Coverage/CoverageMergerTest.php
+++ b/test/functional/Coverage/CoverageMergerTest.php
@@ -149,33 +149,33 @@ class CoverageMergerTest extends TestBase
     public static function getCoverageFileProvider()
     {
         $version = 'CodeCoverage >4.0';
-        $filenames = array(
+        $filenames = [
             'coverage-tests/runner_test.cov',
             'coverage-tests/result_printer_test.cov',
-        );
+        ];
         $coverageClass = 'SebastianBergmann\\CodeCoverage\\CodeCoverage';
         if (class_exists('PHP_CodeCoverage')) {
             $version = 'Legacy CodeCoverage';
-            $filenames = array(
+            $filenames = [
                 'coverage-tests/runner_test.cov4',
                 'coverage-tests/result_printer_test.cov4',
-            );
+            ];
             $coverageClass = 'PHP_CodeCoverage';
             if (Semver::satisfies(static::getPhpUnitVersion(), '3.7.*')) {
                 $version = 'PHPUnit 3.7';
-                $filenames = array(
+                $filenames = [
                     'coverage-tests/runner_test.cov3',
                     'coverage-tests/result_printer_test.cov3',
-                );
+                ];
             }
         }
 
-        return array(
-            $version => array(
+        return [
+            $version => [
                 'filenames' => $filenames,
                 'expected coverage class' => $coverageClass,
-            ),
-        );
+            ],
+        ];
     }
 
     /**

--- a/test/functional/Coverage/CoverageReporterTest.php
+++ b/test/functional/Coverage/CoverageReporterTest.php
@@ -134,32 +134,32 @@ class CoverageReporterTest extends TestBase
     public static function getReporterProvider()
     {
         $version = 'CodeCoverage >4.0';
-        $filenames = array(
+        $filenames = [
             'coverage-tests/runner_test.cov',
             'coverage-tests/result_printer_test.cov',
-        );
+        ];
         $reporterClass = 'ParaTest\\Coverage\\CoverageReporter';
         if (class_exists('\PHP_CodeCoverage')) {
             $version = 'Legacy CodeCoverage';
-            $filenames = array(
+            $filenames = [
                 'coverage-tests/runner_test.cov4',
                 'coverage-tests/result_printer_test.cov4',
-            );
+            ];
             $reporterClass = 'ParaTest\\Coverage\\CoverageReporterLegacy';
             if (Semver::satisfies(static::getPhpUnitVersion(), '3.7.*')) {
                 $version = 'PHPUnit 3.7';
-                $filenames = array(
+                $filenames = [
                     'coverage-tests/runner_test.cov3',
                     'coverage-tests/result_printer_test.cov3',
-                );
+                ];
             }
         }
 
-        return array(
-            $version => array(
+        return [
+            $version => [
                 'filenames' => $filenames,
                 'expected reporter class' => $reporterClass,
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/test/functional/DataProviderTest.php
+++ b/test/functional/DataProviderTest.php
@@ -16,60 +16,60 @@ class DataProviderTest extends FunctionalTestBase
 
     public function testFunctionalMode()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional"     => null,
             "max-batch-size" => 50,
-        ));
+        ]);
         $this->assertRegExp('/OK \(1100 tests, 1100 assertions\)/', $proc->getOutput());
     }
 
     public function testNumericDataSetInFunctionalModeWithMethodFilter()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional"     => null,
             "max-batch-size" => 50,
             "filter" => "testNumericDataProvider50"
-        ));
+        ]);
         $this->assertRegExp('/OK \(50 tests, 50 assertions\)/', $proc->getOutput());
     }
 
     public function testNumericDataSetInFunctionalModeWithCustomFilter()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional"     => null,
             "max-batch-size" => 50,
             "filter" => "testNumericDataProvider50.*1"
-        ));
+        ]);
         $this->assertRegExp('/OK \(14 tests, 14 assertions\)/', $proc->getOutput());
     }
 
     public function testNamedDataSetInFunctionalModeWithMethodFilter()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional"     => null,
             "max-batch-size" => 50,
             "filter" => "testNamedDataProvider50"
-        ));
+        ]);
         $this->assertRegExp('/OK \(50 tests, 50 assertions\)/', $proc->getOutput());
     }
 
     public function testNamedDataSetInFunctionalModeWithCustomFilter()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional"     => null,
             "max-batch-size" => 50,
             "filter" => "testNamedDataProvider50.*name_of_test_.*1"
-        ));
+        ]);
         $this->assertRegExp('/OK \(14 tests, 14 assertions\)/', $proc->getOutput());
     }
 
     public function testNumericDataSet1000InFunctionalModeWithFilterAndMaxBatchSize()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional"     => null,
             "max-batch-size" => 50,
             "filter" => "testNumericDataProvider1000"
-        ));
+        ]);
         $this->assertRegExp('/OK \(1000 tests, 1000 assertions\)/', $proc->getOutput());
     }
 }

--- a/test/functional/FunctionalTestBase.php
+++ b/test/functional/FunctionalTestBase.php
@@ -15,7 +15,7 @@ class FunctionalTestBase extends PHPUnit\Framework\TestCase
         return $fixture;
     }
 
-    protected function invokeParatest($path, $options = array(), $callback = null)
+    protected function invokeParatest($path, $options = [], $callback = null)
     {
         $invoker = new ParaTestInvoker($this->fixture($path), BOOTSTRAP);
         return $invoker->execute($options, $callback);

--- a/test/functional/GroupTest.php
+++ b/test/functional/GroupTest.php
@@ -15,38 +15,38 @@ class GroupTest extends FunctionalTestBase
 
     public function testGroupSwitchOnlyExecutesThoseGroups()
     {
-        $proc = $this->invoker->execute(array('group' => 'group1'));
+        $proc = $this->invoker->execute(['group' => 'group1']);
         $this->assertRegExp('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
     }
 
     public function testExcludeGroupSwitchDontExecuteThatGroup()
     {
-        $proc = $this->invoker->execute(array('exclude-group' => 'group1'));
+        $proc = $this->invoker->execute(['exclude-group' => 'group1']);
 
         $this->assertRegExp('/OK \(3 tests, 3 assertions\)/', $proc->getOutput());
     }
 
     public function testGroupSwitchExecutesGroupsUsingShortOption()
     {
-        $proc = $this->invoker->execute(array('g' => 'group1'));
+        $proc = $this->invoker->execute(['g' => 'group1']);
         $this->assertRegExp('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
     }
 
     public function testGroupSwitchOnlyExecutesThoseGroupsInFunctionalMode()
     {
-        $proc = $this->invoker->execute(array('functional', 'g' => 'group1'));
+        $proc = $this->invoker->execute(['functional', 'g' => 'group1']);
         $this->assertRegExp('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
     }
 
     public function testGroupSwitchOnlyExecutesThoseGroupsWhereTestHasMultipleGroups()
     {
-        $proc = $this->invoker->execute(array('functional', 'group' => 'group3'));
+        $proc = $this->invoker->execute(['functional', 'group' => 'group3']);
         $this->assertRegExp('/OK \(1 test, 1 assertion\)/', $proc->getOutput());
     }
 
     public function testGroupsSwitchExecutesMultipleGroups()
     {
-        $proc = $this->invoker->execute(array('functional', 'group' => 'group1,group3'));
+        $proc = $this->invoker->execute(['functional', 'group' => 'group1,group3']);
         $this->assertRegExp('/OK \(3 tests, 3 assertions\)/', $proc->getOutput());
     }
 }

--- a/test/functional/OutputTest.php
+++ b/test/functional/OutputTest.php
@@ -23,7 +23,7 @@ class OutputTest extends FunctionalTestBase
     public function testMessagePrintedWhenInvalidConfigFileSupplied()
     {
         $output = $this->paratest
-            ->execute(array('configuration' => 'nope.xml'))
+            ->execute(['configuration' => 'nope.xml'])
             ->getOutput();
         $this->assertContains('Could not read "nope.xml"', $output);
     }
@@ -31,7 +31,7 @@ class OutputTest extends FunctionalTestBase
     public function testMessagePrintedWhenFunctionalModeIsOn()
     {
         $output = $this->paratest
-            ->execute(array('functional'))
+            ->execute(['functional'])
             ->getOutput();
         $this->assertContains("Running phpunit in 5 processes with " . PHPUNIT, $output);
         $this->assertContains("Functional mode is ON.", $output);
@@ -40,7 +40,7 @@ class OutputTest extends FunctionalTestBase
 
     public function testProcCountIsReportedWithProcOption()
     {
-        $output = $this->paratest->execute(array('p'=>1))
+        $output = $this->paratest->execute(['p'=>1])
             ->getOutput();
         $this->assertContains("Running phpunit in 1 process with " . PHPUNIT, $output);
         $this->assertRegExp('/[.F]{4}/', $output);

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -4,15 +4,15 @@ class PHPUnitTest extends FunctionalTestBase
 {
     public function testWithJustBootstrap()
     {
-        $this->assertTestsPassed($this->invokeParatest('passing-tests', array(
+        $this->assertTestsPassed($this->invokeParatest('passing-tests', [
             'bootstrap' => BOOTSTRAP
-        )));
+        ]));
     }
 
     public function testWithBootstrapThatDoesNotExist()
     {
         $bootstrap = '/fileThatDoesNotExist.php';
-        $proc = $this->invokeParatest('passing-tests', array('bootstrap' => $bootstrap));
+        $proc = $this->invokeParatest('passing-tests', ['bootstrap' => $bootstrap]);
         $errors = $proc->getErrorOutput();
         $this->assertEquals(1, $proc->getExitCode(), 'Unexpected exit code');
         $this->assertContains('[RuntimeException]', $errors, 'Expected exception name not found in output');
@@ -21,17 +21,17 @@ class PHPUnitTest extends FunctionalTestBase
 
     public function testWithJustConfiguration()
     {
-        $this->assertTestsPassed($this->invokeParatest('passing-tests', array(
+        $this->assertTestsPassed($this->invokeParatest('passing-tests', [
             'configuration' => PHPUNIT_CONFIGURATION
-        )));
+        ]));
     }
 
     public function testWithWrapperRunner()
     {
-        $this->assertTestsPassed($this->invokeParatest('passing-tests', array(
+        $this->assertTestsPassed($this->invokeParatest('passing-tests', [
             'configuration' => PHPUNIT_CONFIGURATION,
             'runner' => 'WrapperRunner'
-        )));
+        ]));
     }
 
     public function testWithCustomRunner()
@@ -40,11 +40,11 @@ class PHPUnitTest extends FunctionalTestBase
 
         $this->invokeParatest(
             'passing-tests',
-            array(
+            [
                 'configuration' => PHPUNIT_CONFIGURATION,
                 'runner'        => 'EmptyRunnerStub'
-            ),
-            array($cb, 'callback')
+            ],
+            [$cb, 'callback']
         );
         $this->assertEquals('EXECUTED', $cb->getBuffer());
     }
@@ -52,7 +52,7 @@ class PHPUnitTest extends FunctionalTestBase
     public function testWithColorsGreenBar()
     {
         $proc = $this->invokeParatest('paratest-only-tests/EnvironmentTest.php',
-            array('bootstrap' => BOOTSTRAP, 'colors'));
+            ['bootstrap' => BOOTSTRAP, 'colors']);
         $this->assertContains(
             "[30;42m[2KOK",
             $proc->getOutput()
@@ -62,7 +62,7 @@ class PHPUnitTest extends FunctionalTestBase
     public function testWithColorsRedBar()
     {
         $proc = $this->invokeParatest('failing-tests/UnitTestWithErrorTest.php',
-            array('bootstrap' => BOOTSTRAP, 'colors'));
+            ['bootstrap' => BOOTSTRAP, 'colors']);
         $this->assertContains(
             "[37;41m[2KFAILURES",
             $proc->getOutput()
@@ -72,21 +72,21 @@ class PHPUnitTest extends FunctionalTestBase
     public function testParatestEnvironmentVariable()
     {
         $this->assertTestsPassed($this->invokeParatest('paratest-only-tests/EnvironmentTest.php',
-            array('bootstrap' => BOOTSTRAP)
+            ['bootstrap' => BOOTSTRAP]
         ));
     }
 
     public function testParatestEnvironmentVariableWithWrapperRunner()
     {
         $this->assertTestsPassed($this->invokeParatest('paratest-only-tests/EnvironmentTest.php',
-            array('bootstrap' => BOOTSTRAP, 'runner' => 'WrapperRunner')
+            ['bootstrap' => BOOTSTRAP, 'runner' => 'WrapperRunner']
         ));
     }
 
     public function testParatestEnvironmentVariableWithWrapperRunnerandWithoutTestTokens()
     {
         $proc = $this->invokeParatest('paratest-only-tests/EnvironmentTest.php',
-            array('bootstrap' => BOOTSTRAP, 'runner' => 'WrapperRunner', 'no-test-tokens' => 0));
+            ['bootstrap' => BOOTSTRAP, 'runner' => 'WrapperRunner', 'no-test-tokens' => 0]);
         $this->assertRegexp('/Failures: 1/', $proc->getOutput());
     }
 
@@ -99,28 +99,28 @@ class PHPUnitTest extends FunctionalTestBase
     public function testWithConfigurationThatDoesNotExist()
     {
         $proc = $this->invokeParatest('passing-tests',
-            array('configuration' => FIXTURES . DS . 'phpunit.xml.disto'));
+            ['configuration' => FIXTURES . DS . 'phpunit.xml.disto']);
         $this->assertRegExp('/Could not read ".*phpunit.xml.disto"./', $proc->getOutput());
     }
 
     public function testFunctionalWithBootstrap()
     {
         $this->assertTestsPassed($this->invokeParatest('passing-tests',
-            array('bootstrap' => BOOTSTRAP, 'functional')
+            ['bootstrap' => BOOTSTRAP, 'functional']
         ));
     }
 
     public function testFunctionalWithConfiguration()
     {
         $this->assertTestsPassed($this->invokeParatest('passing-tests',
-            array('configuration' => PHPUNIT_CONFIGURATION, 'functional')
+            ['configuration' => PHPUNIT_CONFIGURATION, 'functional']
         ));
     }
 
     public function testWithBootstrapAndProcessesSwitch()
     {
         $proc = $this->invokeParatest('passing-tests',
-            array('bootstrap' => BOOTSTRAP, 'processes' => 6));
+            ['bootstrap' => BOOTSTRAP, 'processes' => 6]);
         $this->assertRegExp('/Running phpunit in 6 processes/', $proc->getOutput());
         $this->assertTestsPassed($proc);
     }
@@ -128,7 +128,7 @@ class PHPUnitTest extends FunctionalTestBase
     public function testWithBootstrapAndManuallySpecifiedPHPUnit()
     {
         $this->assertTestsPassed($this->invokeParatest('passing-tests',
-            array('bootstrap' => BOOTSTRAP, 'phpunit' => PHPUNIT)
+            ['bootstrap' => BOOTSTRAP, 'phpunit' => PHPUNIT]
         ));
     }
 
@@ -142,7 +142,7 @@ class PHPUnitTest extends FunctionalTestBase
     {
         chdir(PARATEST_ROOT);
         $this->assertTestsPassed($this->invokeParatest('passing-tests',
-            array('path' => 'test/fixtures/passing-tests')
+            ['path' => 'test/fixtures/passing-tests']
         ));
     }
 
@@ -150,9 +150,9 @@ class PHPUnitTest extends FunctionalTestBase
     {
         chdir(PARATEST_ROOT);
         $output = FIXTURES . DS . 'logs' . DS . 'functional-directory.xml';
-        $proc = $this->invokeParatest('passing-tests', array(
+        $proc = $this->invokeParatest('passing-tests', [
             'log-junit' => $output
-        ));
+        ]);
         $this->assertTestsPassed($proc);
         $this->assertTrue(file_exists($output));
         if(file_exists($output)) unlink($output);
@@ -162,7 +162,7 @@ class PHPUnitTest extends FunctionalTestBase
     {
         chdir(PARATEST_ROOT);
         $proc = $this->invokeParatest('passing-tests',
-            array('path' => 'test/fixtures/paratest-only-tests/TestTokenTest.php'));
+            ['path' => 'test/fixtures/paratest-only-tests/TestTokenTest.php']);
         $this->assertTestsPassed($proc, 1, 1);
     }
 
@@ -170,10 +170,10 @@ class PHPUnitTest extends FunctionalTestBase
     {
         chdir(PARATEST_ROOT);
         $output = FIXTURES . DS . 'logs' . DS . 'functional-file.xml';
-        $proc = $this->invokeParatest('passing-tests/GroupsTest.php', array(
+        $proc = $this->invokeParatest('passing-tests/GroupsTest.php', [
             'log-junit' => $output,
             'bootstrap' => BOOTSTRAP
-        ));
+        ]);
         $this->assertTestsPassed($proc, 5, 5);
         $this->assertTrue(file_exists($output));
         if(file_exists($output)) unlink($output);
@@ -181,25 +181,25 @@ class PHPUnitTest extends FunctionalTestBase
 
     public function testSuccessfulRunHasExitCode0()
     {
-        $proc = $this->invokeParatest('passing-tests/GroupsTest.php', array(
+        $proc = $this->invokeParatest('passing-tests/GroupsTest.php', [
             'bootstrap' => BOOTSTRAP
-        ));
+        ]);
         $this->assertEquals(0, $proc->getExitCode());
     }
 
     public function testFailedRunHasExitCode1()
     {
-        $proc = $this->invokeParatest('failing-tests/FailingTest.php',array(
+        $proc = $this->invokeParatest('failing-tests/FailingTest.php',[
             'bootstrap' => BOOTSTRAP
-        ));
+        ]);
         $this->assertEquals(1, $proc->getExitCode());
     }
 
     public function testRunWithErrorsHasExitCode2()
     {
-        $proc = $this->invokeParatest('failing-tests/UnitTestWithErrorTest.php', array(
+        $proc = $this->invokeParatest('failing-tests/UnitTestWithErrorTest.php', [
             'bootstrap' => BOOTSTRAP
-        ));
+        ]);
         $this->assertEquals(2, $proc->getExitCode());
     }
 
@@ -210,9 +210,9 @@ class PHPUnitTest extends FunctionalTestBase
      */
     public function testRunWithFatalParseErrorsHasExitCode255or1()
     {
-        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalParseErrorTest.php', array(
+        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalParseErrorTest.php', [
             'bootstrap' => BOOTSTRAP
-        ));
+        ]);
         $this->assertTrue(in_array($proc->getExitCode(), [1, 255], true));
     }
 
@@ -221,9 +221,9 @@ class PHPUnitTest extends FunctionalTestBase
         if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('fatals are handled like normal exceptions with php7');
         }
-        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', array(
+        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', [
             'bootstrap' => BOOTSTRAP
-        ));
+        ]);
         $this->assertEquals(1, $proc->getExitCode());
     }
 
@@ -232,9 +232,9 @@ class PHPUnitTest extends FunctionalTestBase
         if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('fatals are handled like normal exceptions with php7');
         }
-        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', array(
+        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', [
             'bootstrap' => BOOTSTRAP
-        ));
+        ]);
         $this->assertContains('Call to undefined function inexistent', $proc->getErrorOutput());
     }
 
@@ -243,21 +243,21 @@ class PHPUnitTest extends FunctionalTestBase
         if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('fatals are handled like normal exceptions with php7');
         }
-        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', array(
+        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', [
             'bootstrap' => BOOTSTRAP,
             'runner' => 'WrapperRunner'
-        ));
+        ]);
         $this->assertContains('Call to undefined function inexistent', $proc->getErrorOutput());
     }
 
     public function testStopOnFailurePreventsStartingFurtherTestsAfterFailure()
     {
-        $proc = $this->invokeParatest('failing-tests/StopOnFailureTest.php', array(
+        $proc = $this->invokeParatest('failing-tests/StopOnFailureTest.php', [
             'bootstrap' => BOOTSTRAP,
             'stop-on-failure' => '',
             'f' => '',
             'p' => '1'
-        ));
+        ]);
         $results = $proc->getOutput();
         $this->assertContains('Tests: 2,', $results);     // The suite actually has 4 tests
         $this->assertContains('Failures: 1,', $results);  // The suite actually has 2 failing tests
@@ -266,13 +266,13 @@ class PHPUnitTest extends FunctionalTestBase
     public function testFullyConfiguredRun()
     {
         $output = FIXTURES . DS . 'logs' . DS . 'functional.xml';
-        $proc = $this->invokeParatest('passing-tests', array(
+        $proc = $this->invokeParatest('passing-tests', [
             'bootstrap' => BOOTSTRAP,
             'phpunit' => PHPUNIT,
             'f' => '',
             'p' => '6',
             'log-junit' => $output
-        ));
+        ]);
         $this->assertTestsPassed($proc);
         $results = $proc->getOutput();
         $this->assertRegExp('/Running phpunit in 6 processes/', $results);
@@ -284,14 +284,14 @@ class PHPUnitTest extends FunctionalTestBase
     public function testUsingDefaultLoadedConfiguration()
     {
         $this->assertTestsPassed($this->invokeParatest('passing-tests',
-            array('functional')
+            ['functional']
         ));
     }
 
     public function testEachTestRunsExactlyOnceOnChainDependencyOnFunctionalMode()
     {
         $proc = $this->invokeParatest('passing-tests/DependsOnChain.php',
-            array('bootstrap' => BOOTSTRAP, 'functional')
+            ['bootstrap' => BOOTSTRAP, 'functional']
         );
         $this->assertTestsPassed($proc, 5, 5);
     }
@@ -299,7 +299,7 @@ class PHPUnitTest extends FunctionalTestBase
     public function testEachTestRunsExactlyOnceOnSameDependencyOnFunctionalMode()
     {
         $proc = $this->invokeParatest('passing-tests/DependsOnSame.php',
-            array('bootstrap' => BOOTSTRAP, 'functional')
+            ['bootstrap' => BOOTSTRAP, 'functional']
         );
         $this->assertTestsPassed($proc, 3, 3);
     }
@@ -307,31 +307,31 @@ class PHPUnitTest extends FunctionalTestBase
     public function testFunctionalModeEachTestCalledOnce()
     {
         $proc = $this->invokeParatest("passing-tests/FunctionalModeEachTestCalledOnce.php",
-            array('bootstrap' => BOOTSTRAP, 'functional')
+            ['bootstrap' => BOOTSTRAP, 'functional']
         );
         $this->assertTestsPassed($proc, 2, 2);
     }
 
     public function setsCoveragePhpDataProvider()
     {
-        return array(
-            array(
-                array('coverage-html' => 'wayne'),
+        return [
+            [
+                ['coverage-html' => 'wayne'],
                 ''
-            ),
-            array(
-                array('coverage-clover' => 'wayne'),
+            ],
+            [
+                ['coverage-clover' => 'wayne'],
                 ''
-            ),
-            array(
-                array('coverage-php' => 'notWayne'),
+            ],
+            [
+                ['coverage-php' => 'notWayne'],
                 'notWayne'
-            ),
-            array(
-                array('coverage-clover' => 'wayne', 'coverage-php' => 'notWayne'),
+            ],
+            [
+                ['coverage-clover' => 'wayne', 'coverage-php' => 'notWayne'],
                 'notWayne'
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -345,7 +345,7 @@ class PHPUnitTest extends FunctionalTestBase
         $phpUnit = new \ParaTest\Console\Testers\PHPUnit();
         $c = new \ParaTest\Console\Commands\ParaTestCommand($phpUnit);
 
-        $input = new \Symfony\Component\Console\Input\ArrayInput(array(), $c->getDefinition());
+        $input = new \Symfony\Component\Console\Input\ArrayInput([], $c->getDefinition());
         foreach ($options as $key => $value) {
             $input->setOption($key, $value);
         }

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -9,7 +9,7 @@ class PHPUnitWarningsTest extends FunctionalTestBase
     {
         $proc = $this->invokeParatest(
             "warning-tests/HasWarningsTest.php",
-            array('bootstrap' => BOOTSTRAP)
+            ['bootstrap' => BOOTSTRAP]
         );
 
         $output = $proc->getOutput();

--- a/test/functional/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
+++ b/test/functional/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
@@ -15,12 +15,12 @@ class RunnerIntegrationTest extends \TestBase
     {
         $this->skipIfCodeCoverageNotEnabled();
 
-        $this->options = array(
+        $this->options = [
             'path' => FIXTURES . DS . 'failing-tests',
             'phpunit' => PHPUNIT,
             'coverage-php' => sys_get_temp_dir() . DS . 'testcoverage.php',
             'bootstrap' => BOOTSTRAP
-        );
+        ];
         if (ParaTestCommand::isWhitelistSupported()) {
             $this->options['whitelist'] = FIXTURES . DS . 'failing-tests';
         }

--- a/test/functional/ParaTest/Runners/PHPUnit/WorkerTest.php
+++ b/test/functional/ParaTest/Runners/PHPUnit/WorkerTest.php
@@ -85,17 +85,17 @@ class WorkerTest extends \TestBase
         $worker = new Worker();
         $this->setPerReflection($worker, 'isRunning', false);
         $this->setPerReflection($worker, 'proc', $this->createSomeClosedProcess());
-        $this->setPerReflection($worker, 'pipes', array(0 => true));
+        $this->setPerReflection($worker, 'pipes', [0 => true]);
         $this->assertFalse($worker->isCrashed());
     }
 
     private function createSomeClosedProcess()
     {
-        $descriptorspec = array(
-            0 => array("pipe", "r"),
-            1 => array("pipe", "w"),
-            2 => array("pipe", "w")
-        );
+        $descriptorspec = [
+            0 => ["pipe", "r"],
+            1 => ["pipe", "w"],
+            2 => ["pipe", "w"]
+        ];
 
         $proc = proc_open('thisCommandHasAnExitcodeNotEqualZero', $descriptorspec, $pipes, '/tmp');
         $running = true;
@@ -136,11 +136,11 @@ class WorkerTest extends \TestBase
         $this->assertJUnitLogIsValid($testLog2);
     }
 
-    protected static $descriptorspec = array(
-       0 => array("pipe", "r"),
-       1 => array("pipe", "w"),
-       2 => array("pipe", "w")
-    );
+    protected static $descriptorspec = [
+       0 => ["pipe", "r"],
+       1 => ["pipe", "w"],
+       2 => ["pipe", "w"]
+    ];
 
     private function getCommand($testFile, $logFile)
     {

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -23,7 +23,7 @@ class ParaTestInvoker
      *
      * @return Process
      */
-    public function execute($options=array(), $callback = null)
+    public function execute($options=[], $callback = null)
     {
         $cmd = $this->buildCommand($options);
         $env = defined('PHP_WINDOWS_VERSION_BUILD') ? Habitat::getAll() : null;
@@ -38,7 +38,7 @@ class ParaTestInvoker
         return $proc;
     }
 
-    private function buildCommand($options=array())
+    private function buildCommand($options=[])
     {
         $cmd = sprintf("%s --bootstrap %s --phpunit %s", PARA_BINARY, $this->bootstrap, PHPUNIT);
         foreach($options as $switch => $value) {

--- a/test/functional/SkippedOrIncompleteTest.php
+++ b/test/functional/SkippedOrIncompleteTest.php
@@ -20,10 +20,10 @@ class SkippedOrIncompleteTest extends FunctionalTestBase
 
     public function testSkippedInFunctionalMode()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional" => null,
             "filter"     => "testSkipped"
-        ));
+        ]);
 
         $expected = "OK, but incomplete, skipped, or risky tests!\n"
                   . "Tests: 1, Assertions: 0, Incomplete: 1.";
@@ -34,10 +34,10 @@ class SkippedOrIncompleteTest extends FunctionalTestBase
 
     public function testIncompleteInFunctionalMode()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional" => null,
             "filter"     => "testIncomplete"
-        ));
+        ]);
 
         $expected = "OK, but incomplete, skipped, or risky tests!\n"
                   . "Tests: 1, Assertions: 0, Incomplete: 1.";
@@ -48,11 +48,11 @@ class SkippedOrIncompleteTest extends FunctionalTestBase
 
     public function testDataProviderWithSkippedInFunctionalMode()
     {
-        $proc = $this->invoker->execute(array(
+        $proc = $this->invoker->execute([
             "functional"     => null,
             "max-batch-size" => 50,
             "filter"         => "testDataProviderWithSkipped"
-        ));
+        ]);
 
         $expected = "OK, but incomplete, skipped, or risky tests!\n"
                   . "Tests: 100, Assertions: 33, Incomplete: 67.";

--- a/test/functional/WrapperRunnerTest.php
+++ b/test/functional/WrapperRunnerTest.php
@@ -10,10 +10,10 @@ class WrapperRunnerTest extends FunctionalTestBase
         $generator = new TestGenerator();
         $generator->generate(self::TEST_CLASSES, self::TEST_METHODS_PER_CLASS);
 
-        $proc = $this->invokeParatest($generator->path, array(
+        $proc = $this->invokeParatest($generator->path, [
             'runner' => 'WrapperRunner',
             'processes' => 3,
-        ));
+        ]);
 
         $expected = self::TEST_CLASSES * self::TEST_METHODS_PER_CLASS;
         $this->assertTestsPassed($proc, $expected, $expected);
@@ -21,10 +21,10 @@ class WrapperRunnerTest extends FunctionalTestBase
 
     public function testMultiLineClassDeclarationWithFilenameDifferentThanClassnameIsSupported()
     {
-        $this->assertTestsPassed($this->invokeParatest('special-classes', array(
+        $this->assertTestsPassed($this->invokeParatest('special-classes', [
             'runner' => 'WrapperRunner',
             'processes' => 3,
-        )));
+        ]));
     }
 
     public function testRunningFewerTestsThanTheWorkersIsPossible()
@@ -32,10 +32,10 @@ class WrapperRunnerTest extends FunctionalTestBase
         $generator = new TestGenerator();
         $generator->generate(1, 1);
 
-        $proc = $this->invokeParatest($generator->path, array(
+        $proc = $this->invokeParatest($generator->path, [
             'runner' => 'WrapperRunner',
             'processes' => 2,
-        ));
+        ]);
 
         $this->assertTestsPassed($proc, 1, 1);
     }
@@ -45,10 +45,10 @@ class WrapperRunnerTest extends FunctionalTestBase
         if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('fatals are handled like normal exceptions with php7');
         }
-        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', array(
+        $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalFunctionErrorTest.php', [
             'runner' => 'WrapperRunner',
             'processes' => 1,
-        ));
+        ]);
 
         $errors = $proc->getErrorOutput();
         $this->assertContains('This worker has crashed', $errors);
@@ -56,7 +56,7 @@ class WrapperRunnerTest extends FunctionalTestBase
 
     public function functionalModeEnabledDataProvider()
     {
-        return array(array(false));
+        return [[false]];
     }
 
     /**
@@ -64,10 +64,10 @@ class WrapperRunnerTest extends FunctionalTestBase
      */
     public function testExitCodes($functionalModeEnabled)
     {
-        $options = array(
+        $options = [
             'runner' => 'WrapperRunner',
             'processes' => 1,
-        );
+        ];
         $proc = $this->invokeParatest('wrapper-runner-exit-code-tests/ErrorTest.php', $options);
         $output = $proc->getOutput();
 

--- a/test/unit/ParaTest/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/ParaTest/Console/Commands/ParaTestCommandTest.php
@@ -28,7 +28,7 @@ class ParaTestCommandTest extends \TestBase
      */
     public function testConfiguredDefinitionWithPHPUnitTester()
     {
-        $options = array(
+        $options = [
             new InputOption('processes', 'p', InputOption::VALUE_REQUIRED, 'The number of test processes to run.', 5),
             new InputOption('functional', 'f', InputOption::VALUE_NONE, 'Run methods instead of suites in separate processes.'),
             new InputOption('help', 'h', InputOption::VALUE_NONE, 'Display this help message.'),
@@ -50,7 +50,7 @@ class ParaTestCommandTest extends \TestBase
             new InputOption('testsuite', null, InputOption::VALUE_OPTIONAL, 'Filter which testsuite to run'),
             new InputOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0),
             new InputOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).'),
-        );
+        ];
         if (ParaTestCommand::isWhitelistSupported()) {
             $options[] = new InputOption('whitelist', null, InputOption::VALUE_REQUIRED, 'Directory to add to the coverage whitelist.');
         }

--- a/test/unit/ParaTest/Console/Testers/PHPUnitTest.php
+++ b/test/unit/ParaTest/Console/Testers/PHPUnitTest.php
@@ -11,7 +11,7 @@ class PHPUnitTest extends \TestBase
     public function testConfigureAddsOptionsAndArgumentsToCommand()
     {
         $testCommand = new TestCommand();
-        $definition = new InputDefinition(array(
+        $definition = new InputDefinition([
             new InputOption('phpunit', null, InputOption::VALUE_REQUIRED, 'The PHPUnit binary to execute. <comment>(default: vendor/bin/phpunit)</comment>'),
             new InputOption('runner', null, InputOption::VALUE_REQUIRED, 'Runner or WrapperRunner. <comment>(default: Runner)</comment>'),
             new InputOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'The bootstrap file to be used by PHPUnit.'),
@@ -24,7 +24,7 @@ class PHPUnitTest extends \TestBase
             new InputArgument('path', InputArgument::OPTIONAL, 'The path to a directory or file containing tests. <comment>(default: current directory)</comment>'),
             new InputOption('path', null, InputOption::VALUE_REQUIRED, 'An alias for the path argument.'),
             new InputOption('testsuite', null, InputOption::VALUE_OPTIONAL, 'Filter which testsuite to run')
-        ));
+        ]);
         $tester = new PHPUnit();
         $tester->configure($testCommand);
         $this->assertEquals($definition, $testCommand->getDefinition());

--- a/test/unit/ParaTest/Coverage/CoverageMergerTest.php
+++ b/test/unit/ParaTest/Coverage/CoverageMergerTest.php
@@ -26,17 +26,17 @@ class CoverageMergerTest extends \TestBase
         $filter->addFilesToWhitelist([$firstFile, $secondFile]);
         $coverage1 = new \PHP_CodeCoverage(null, $filter);
         $coverage1->append(
-            array(
-                $firstFile => array(35 => 1),
-                $secondFile => array(34 => 1)
-            ),
+            [
+                $firstFile => [35 => 1],
+                $secondFile => [34 => 1]
+            ],
             'Test1'
         );
         $coverage2 = new \PHP_CodeCoverage(null, $filter);
         $coverage2->append(
-            array(
-                $firstFile => array(35 => 1, 36 => 1)
-            ),
+            [
+                $firstFile => [35 => 1, 36 => 1]
+            ],
             'Test2'
         );
 
@@ -76,17 +76,17 @@ class CoverageMergerTest extends \TestBase
         $filter->addFilesToWhitelist([$firstFile, $secondFile]);
         $coverage1 = new CodeCoverage(null, $filter);
         $coverage1->append(
-            array(
-                $firstFile => array(35 => 1),
-                $secondFile => array(34 => 1)
-            ),
+            [
+                $firstFile => [35 => 1],
+                $secondFile => [34 => 1]
+            ],
             'Test1'
         );
         $coverage2 = new CodeCoverage(null, $filter);
         $coverage2->append(
-            array(
-                $firstFile => array(35 => 1, 36 => 1)
-            ),
+            [
+                $firstFile => [35 => 1, 36 => 1]
+            ],
             'Test2'
         );
 

--- a/test/unit/ParaTest/Logging/JUnit/ReaderTest.php
+++ b/test/unit/ParaTest/Logging/JUnit/ReaderTest.php
@@ -208,7 +208,7 @@ class ReaderTest extends \TestBase
         $totalCases = 7;
         $casesProcessed = 0;
         $feedback = $this->mixed->getFeedback($totalCases, $casesProcessed);
-        $this->assertEquals(array('.', 'F', '.', 'E', '.', 'F', '.'), $feedback);
+        $this->assertEquals(['.', 'F', '.', 'E', '.', 'F', '.'], $feedback);
     }
 
     public function testRemoveLog()

--- a/test/unit/ParaTest/Logging/LogInterpreterTest.php
+++ b/test/unit/ParaTest/Logging/LogInterpreterTest.php
@@ -19,7 +19,7 @@ class LogInterpreterTest extends ResultTester
     public function testConstructor()
     {
         $interpreter = new LogInterpreter();
-        $this->assertEquals(array(), $this->getObjectValue($interpreter, 'readers'));
+        $this->assertEquals([], $this->getObjectValue($interpreter, 'readers'));
     }
 
     public function testAddReaderIncrementsReaders()
@@ -94,14 +94,14 @@ class LogInterpreterTest extends ResultTester
 
     public function testGetErrorsReturnsArrayOfErrorMessages()
     {
-        $errors = array("UnitTestWithErrorTest::testTruth\nException: Error!!!\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithErrorTest.php:12");
+        $errors = ["UnitTestWithErrorTest::testTruth\nException: Error!!!\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithErrorTest.php:12"];
         $this->assertEquals($errors, $this->interpreter->getErrors());
     }
 
     public function testGetFailuresReturnsArrayOfFailureMessages()
     {
-        $failures = array("UnitTestWithClassAnnotationTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php:20",
-"UnitTestWithMethodAnnotationsTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18");
+        $failures = ["UnitTestWithClassAnnotationTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php:20",
+"UnitTestWithMethodAnnotationsTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18"];
         $this->assertEquals($failures, $this->interpreter->getFailures());
     }
 

--- a/test/unit/ParaTest/Parser/ParsedClassTest.php
+++ b/test/unit/ParaTest/Parser/ParsedClassTest.php
@@ -7,7 +7,7 @@ class ParsedClassTest extends \TestBase
 
     public function setUp()
     {
-        $this->methods = array(
+        $this->methods = [
             new ParsedFunction(
                 "/**
               * @group group1
@@ -21,7 +21,7 @@ class ParsedClassTest extends \TestBase
                 'public', 'testFunction2'
             ),
             new ParsedFunction('', 'public', 'testFunction3')
-        );
+        ];
         $this->class = new ParsedClass('', 'MyTestClass', '', $this->methods);
     }
 
@@ -50,14 +50,14 @@ class ParsedClassTest extends \TestBase
               */",
             'public', 'testFunction2'
         );
-        $annotatedClass = new ParsedClass('', 'MyTestClass', '', array($goodMethod, $goodMethod2, $badMethod));
-        $methods = $annotatedClass->getMethods(array('group' => 'group1,group2'));
-        $this->assertEquals(array($goodMethod, $goodMethod2), $methods);
+        $annotatedClass = new ParsedClass('', 'MyTestClass', '', [$goodMethod, $goodMethod2, $badMethod]);
+        $methods = $annotatedClass->getMethods(['group' => 'group1,group2']);
+        $this->assertEquals([$goodMethod, $goodMethod2], $methods);
     }
 
     public function testGetMethodsExceptsAdditionalAnnotationFilter()
     {
-        $group1 = $this->class->getMethods(array('group' => 'group1'));
+        $group1 = $this->class->getMethods(['group' => 'group1']);
         $this->assertEquals(1, sizeof($group1));
         $this->assertEquals($this->methods[0], $group1[0]);
     }

--- a/test/unit/ParaTest/ResultTester.php
+++ b/test/unit/ParaTest/ResultTester.php
@@ -25,7 +25,7 @@ abstract class ResultTester extends \TestBase
     public function getSuiteWithResult($result, $methodCount)
     {
         $result = FIXTURES . DS . 'results' . DS . $result;
-        $functions = array();
+        $functions = [];
         for ($i = 0; $i < $methodCount; $i++) {
             $functions[] = $this->mockFunction($i);
         }

--- a/test/unit/ParaTest/Runners/PHPUnit/ExecutableTestTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/ExecutableTestTest.php
@@ -22,7 +22,7 @@ class ExecutableTestTest extends \TestBase
 
     public function testGetCommandStringIncludesOptions()
     {
-        $options = array('bootstrap' => 'test/bootstrap.php');
+        $options = ['bootstrap' => 'test/bootstrap.php'];
         $binary = '/usr/bin/phpunit';
 
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options);
@@ -31,7 +31,7 @@ class ExecutableTestTest extends \TestBase
 
     public function testCommandRedirectsCoverage()
     {
-        $options = array('a' => 'b', 'coverage-php' => 'target_html', 'coverage-php' => 'target.php');
+        $options = ['a' => 'b', 'coverage-php' => 'target_html', 'coverage-php' => 'target.php'];
         $binary = '/usr/bin/phpunit';
 
         $command = $this->executableTestChild->command($binary, $options);
@@ -41,9 +41,9 @@ class ExecutableTestTest extends \TestBase
 
     public function testGetCommandStringDoesNotIncludeEnvironmentVariablesToKeepCompatibilityWithWindows()
     {
-        $options = array('bootstrap' => 'test/bootstrap.php');
+        $options = ['bootstrap' => 'test/bootstrap.php'];
         $binary = '/usr/bin/phpunit';
-        $environmentVariables = array('APPLICATION_ENVIRONMENT_VAR' => 'abc');
+        $environmentVariables = ['APPLICATION_ENVIRONMENT_VAR' => 'abc'];
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options, $environmentVariables);
 
         $this->assertEquals("'/usr/bin/phpunit' '--bootstrap' 'test/bootstrap.php' 'ClassNameTest' 'pathToFile'", $command);
@@ -51,7 +51,7 @@ class ExecutableTestTest extends \TestBase
 
     public function testGetCommandStringIncludesTheClassName()
     {
-        $options = array();
+        $options = [];
         $binary = '/usr/bin/phpunit';
 
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options);
@@ -60,7 +60,7 @@ class ExecutableTestTest extends \TestBase
 
     public function testHandleEnvironmentVariablesAssignsToken()
     {
-        $environmentVariables = array('TEST_TOKEN' => 3, 'APPLICATION_ENVIRONMENT_VAR' => 'abc');
+        $environmentVariables = ['TEST_TOKEN' => 3, 'APPLICATION_ENVIRONMENT_VAR' => 'abc'];
         $this->call($this->executableTestChild, 'handleEnvironmentVariables', $environmentVariables);
         $this->assertEquals(3, $this->getObjectValue($this->executableTestChild, 'token'));
     }

--- a/test/unit/ParaTest/Runners/PHPUnit/OptionsTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/OptionsTest.php
@@ -7,14 +7,14 @@ class OptionsTest extends \TestBase
 
     public function setUp()
     {
-        $this->unfiltered = array(
+        $this->unfiltered = [
             'processes' => 5,
             'path' => '/path/to/tests',
             'phpunit' => 'phpunit',
             'functional' => true,
             'group' => 'group1',
             'bootstrap' => '/path/to/bootstrap'
-        ); 
+        ]; 
         $this->options = new Options($this->unfiltered);
         $this->cleanUpConfigurations();
     }
@@ -33,7 +33,7 @@ class OptionsTest extends \TestBase
 
     public function testAnnotationsDefaultsToEmptyArray()
     {
-        $options = new Options(array());
+        $options = new Options([]);
         $this->assertEmpty($options->annotations);
     }
 

--- a/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/ResultPrinterTest.php
@@ -25,7 +25,7 @@ class ResultPrinterTest extends ResultTester
 
     public function testConstructor()
     {
-        $this->assertEquals(array(), $this->getObjectValue($this->printer, 'suites'));
+        $this->assertEquals([], $this->getObjectValue($this->printer, 'suites'));
         $this->assertInstanceOf(
             'ParaTest\\Logging\\LogInterpreter',
             $this->getObjectValue($this->printer, 'results')
@@ -34,16 +34,16 @@ class ResultPrinterTest extends ResultTester
 
     public function testAddTestShouldaddTest()
     {
-        $suite = new Suite('/path/to/ResultSuite.php', array());
+        $suite = new Suite('/path/to/ResultSuite.php', []);
 
         $this->printer->addTest($suite);
 
-        $this->assertEquals(array($suite), $this->getObjectValue($this->printer, 'suites'));
+        $this->assertEquals([$suite], $this->getObjectValue($this->printer, 'suites'));
     }
 
     public function testAddTestReturnsSelf()
     {
-        $suite = new Suite('/path/to/ResultSuite.php', array());
+        $suite = new Suite('/path/to/ResultSuite.php', []);
 
         $self = $this->printer->addTest($suite);
 
@@ -60,7 +60,7 @@ class ResultPrinterTest extends ResultTester
 
     public function testStartSetsWidthAndMaxColumn()
     {
-        $funcs = array();
+        $funcs = [];
         for($i = 0; $i < 120; $i++)
             $funcs[] = new ParsedFunction('doc', 'public', 'function' . $i);
         $suite = new Suite('/path', $funcs);
@@ -75,7 +75,7 @@ class ResultPrinterTest extends ResultTester
     public function testStartPrintsOptionInfoAndConfigurationDetailsIfConfigFilePresent()
     {
         file_put_contents('myconfig.xml', '<root />');
-        $options = new Options(array('configuration' => 'myconfig.xml'));
+        $options = new Options(['configuration' => 'myconfig.xml']);
         $contents = $this->getStartOutput($options);
         $expected = sprintf("\nRunning phpunit in 5 processes with %s\n\nConfiguration read from %s\n\n",
                             $options->phpunit,
@@ -85,7 +85,7 @@ class ResultPrinterTest extends ResultTester
 
     public function testStartPrintsOptionInfoWithFunctionalMode()
     {
-        $options = new Options(array('functional' => true));
+        $options = new Options(['functional' => true]);
         $contents = $this->getStartOutput($options);
         $expected = sprintf("\nRunning phpunit in 5 processes with %s. Functional mode is ON.\n\n", $options->phpunit);
         $this->assertStringStartsWith($expected, $contents);
@@ -93,7 +93,7 @@ class ResultPrinterTest extends ResultTester
 
     public function testStartPrintsOptionInfoWithSingularForOneProcess()
     {
-        $options = new Options(array('processes' => 1));
+        $options = new Options(['processes' => 1]);
         $contents = $this->getStartOutput($options);
         $expected = sprintf("\nRunning phpunit in 1 process with %s\n\n", $options->phpunit);
         $this->assertStringStartsWith($expected, $contents);
@@ -101,10 +101,10 @@ class ResultPrinterTest extends ResultTester
 
     public function testAddSuiteAddsFunctionCountToTotalTestCases()
     {
-        $suite = new Suite('/path', array(
+        $suite = new Suite('/path', [
             new ParsedFunction('doc', 'public', 'funcOne'),
             new ParsedFunction('doc', 'public', 'funcTwo')
-        ));
+        ]);
         $this->printer->addTest($suite);
         $this->assertEquals(2, $this->printer->getTotalCases());
     }

--- a/test/unit/ParaTest/Runners/PHPUnit/RunnerTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/RunnerTest.php
@@ -13,19 +13,19 @@ class RunnerTest extends \TestBase
 
     public function testConstructor()
     {
-        $opts = array('processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true);
+        $opts = ['processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true];
         $runner = new Runner($opts);
         $options = $this->getObjectValue($runner, 'options');
 
         $this->assertEquals(4, $options->processes);
         $this->assertEquals(FIXTURES . DS . 'tests', $options->path);
-        $this->assertEquals(array(), $this->getObjectValue($runner, 'pending'));
-        $this->assertEquals(array(), $this->getObjectValue($runner, 'running'));
+        $this->assertEquals([], $this->getObjectValue($runner, 'pending'));
+        $this->assertEquals([], $this->getObjectValue($runner, 'running'));
         $this->assertEquals(-1, $this->getObjectValue($runner, 'exitcode'));
         $this->assertTrue($options->functional);
         //filter out processes and path and phpunit
         $config = new Configuration(getcwd() . DS . 'phpunit.xml.dist');
-        $this->assertEquals(array('bootstrap' => 'hello', 'configuration' => $config), $options->filtered);
+        $this->assertEquals(['bootstrap' => 'hello', 'configuration' => $config], $options->filtered);
         $this->assertInstanceOf('ParaTest\\Logging\\LogInterpreter', $this->getObjectValue($runner, 'interpreter'));
         $this->assertInstanceOf('ParaTest\\Runners\\PHPUnit\\ResultPrinter', $this->getObjectValue($runner, 'printer'));
     }
@@ -37,7 +37,7 @@ class RunnerTest extends \TestBase
 
     public function testConstructorAssignsTokens()
     {
-        $opts = array('processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true);
+        $opts = ['processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true];
         $runner = new Runner($opts);
         $tokens = $this->getObjectValue($runner, 'tokens');
         $this->assertEquals(4, count($tokens));
@@ -45,13 +45,13 @@ class RunnerTest extends \TestBase
 
     public function testGetsNextAvailableTokenReturnsTokenIdentifier()
     {
-        $tokens = array(
-            0 => array('token' => 0, 'unique' => uniqid(), 'available' => false),
-            1 => array('token' => 1, 'unique' => uniqid(), 'available' => false),
-            2 => array('token' => 2, 'unique' => uniqid(), 'available' => true),
-            3 => array('token' => 3, 'unique' => uniqid(), 'available' => false)
-        );
-        $opts = array('processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true);
+        $tokens = [
+            0 => ['token' => 0, 'unique' => uniqid(), 'available' => false],
+            1 => ['token' => 1, 'unique' => uniqid(), 'available' => false],
+            2 => ['token' => 2, 'unique' => uniqid(), 'available' => true],
+            3 => ['token' => 3, 'unique' => uniqid(), 'available' => false]
+        ];
+        $opts = ['processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true];
         $runner = new Runner($opts);
         $this->setObjectValue($runner, 'tokens', $tokens);
 
@@ -61,13 +61,13 @@ class RunnerTest extends \TestBase
 
     public function testGetNextAvailableTokenReturnsFalseWhenNoTokensAreAvailable()
     {
-        $tokens = array(
-            0 => array('token' => 0, 'unique' => uniqid(), 'available' => false),
-            1 => array('token' => 1, 'unique' => uniqid(), 'available' => false),
-            2 => array('token' => 2, 'unique' => uniqid(), 'available' => false),
-            3 => array('token' => 3, 'unique' => uniqid(), 'available' => false)
-        );
-        $opts = array('processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true);
+        $tokens = [
+            0 => ['token' => 0, 'unique' => uniqid(), 'available' => false],
+            1 => ['token' => 1, 'unique' => uniqid(), 'available' => false],
+            2 => ['token' => 2, 'unique' => uniqid(), 'available' => false],
+            3 => ['token' => 3, 'unique' => uniqid(), 'available' => false]
+        ];
+        $opts = ['processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true];
         $runner = new Runner($opts);
         $this->setObjectValue($runner, 'tokens', $tokens);
 
@@ -77,13 +77,13 @@ class RunnerTest extends \TestBase
 
     public function testReleaseTokenMakesTokenAvailable()
     {
-        $tokens = array(
-            0 => array('token' => 0, 'unique' => uniqid(), 'available' => false),
-            1 => array('token' => 1, 'unique' => uniqid(), 'available' => false),
-            2 => array('token' => 2, 'unique' => uniqid(), 'available' => false),
-            3 => array('token' => 3, 'unique' => uniqid(), 'available' => false)
-        );
-        $opts = array('processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true);
+        $tokens = [
+            0 => ['token' => 0, 'unique' => uniqid(), 'available' => false],
+            1 => ['token' => 1, 'unique' => uniqid(), 'available' => false],
+            2 => ['token' => 2, 'unique' => uniqid(), 'available' => false],
+            3 => ['token' => 3, 'unique' => uniqid(), 'available' => false]
+        ];
+        $opts = ['processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true];
         $runner = new Runner($opts);
         $this->setObjectValue($runner, 'tokens', $tokens);
 

--- a/test/unit/ParaTest/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/SuiteLoaderTest.php
@@ -4,7 +4,7 @@ class SuiteLoaderTest extends \TestBase
 {
     public function testConstructor()
     {
-        $options = new Options(array('group' => 'group1'));
+        $options = new Options(['group' => 'group1']);
         $loader = new SuiteLoader($options);
         $this->assertEquals($options, $this->getObjectValue($loader, 'options'));
     }
@@ -20,7 +20,7 @@ class SuiteLoaderTest extends \TestBase
      */
     public function testOptionsMustBeInstanceOfOptionsIfNotNull()
     {
-        $loader = new SuiteLoader(array('one' => 'two', 'three' => 'four'));
+        $loader = new SuiteLoader(['one' => 'two', 'three' => 'four']);
     }
 
     /**
@@ -45,7 +45,7 @@ class SuiteLoaderTest extends \TestBase
     public function testLoadTestsuiteFileFromConfig()
     {
         $options = new Options(
-            array('configuration' => $this->fixture('phpunit-file.xml'), 'testsuite' => 'ParaTest Fixtures')
+            ['configuration' => $this->fixture('phpunit-file.xml'), 'testsuite' => 'ParaTest Fixtures']
         );
         $loader = new SuiteLoader($options);
         $loader->load();
@@ -58,7 +58,7 @@ class SuiteLoaderTest extends \TestBase
     public function testLoadTestsuiteFilesFromConfigWhileIgnoringExcludeTag()
     {
         $options = new Options(
-            array('configuration' => $this->fixture('phpunit-excluded-including-file.xml'), 'testsuite' => 'ParaTest Fixtures')
+            ['configuration' => $this->fixture('phpunit-excluded-including-file.xml'), 'testsuite' => 'ParaTest Fixtures']
         );
         $loader = new SuiteLoader($options);
         $loader->load();
@@ -71,7 +71,7 @@ class SuiteLoaderTest extends \TestBase
     public function testLoadTestsuiteFilesFromDirFromConfigWhileRespectingExcludeTag()
     {
         $options = new Options(
-            array('configuration' => $this->fixture('phpunit-excluded-including-dir.xml'), 'testsuite' => 'ParaTest Fixtures')
+            ['configuration' => $this->fixture('phpunit-excluded-including-dir.xml'), 'testsuite' => 'ParaTest Fixtures']
         );
         $loader = new SuiteLoader($options);
         $loader->load();
@@ -84,7 +84,7 @@ class SuiteLoaderTest extends \TestBase
     public function testLoadTestsuiteFilesFromConfigWhileIncludingAndExcludingTheSameDirectory()
     {
         $options = new Options(
-            array('configuration' => $this->fixture('phpunit-excluded-including-excluding-same-dir.xml'), 'testsuite' => 'ParaTest Fixtures')
+            ['configuration' => $this->fixture('phpunit-excluded-including-excluding-same-dir.xml'), 'testsuite' => 'ParaTest Fixtures']
         );
         $loader = new SuiteLoader($options);
         $loader->load();
@@ -97,7 +97,7 @@ class SuiteLoaderTest extends \TestBase
     public function testLoadTestsuiteFilesFromConfig()
     {
         $options = new Options(
-            array('configuration' => $this->fixture('phpunit-multifile.xml'), 'testsuite' => 'ParaTest Fixtures')
+            ['configuration' => $this->fixture('phpunit-multifile.xml'), 'testsuite' => 'ParaTest Fixtures']
         );
         $loader = new SuiteLoader($options);
         $loader->load();
@@ -109,7 +109,7 @@ class SuiteLoaderTest extends \TestBase
 
     public function testLoadTestsuiteWithDirectory()
     {
-        $options = new Options(array('configuration' => $this->fixture('phpunit-passing.xml'), 'testsuite' => 'ParaTest Fixtures'));
+        $options = new Options(['configuration' => $this->fixture('phpunit-passing.xml'), 'testsuite' => 'ParaTest Fixtures']);
         $loader = new SuiteLoader($options);
         $loader->load();
         $files = $this->getObjectValue($loader, 'files');
@@ -120,7 +120,7 @@ class SuiteLoaderTest extends \TestBase
 
     public function testLoadTestsuiteWithDirectories()
     {
-        $options = new Options(array('configuration' => $this->fixture('phpunit-multidir.xml'), 'testsuite' => 'ParaTest Fixtures'));
+        $options = new Options(['configuration' => $this->fixture('phpunit-multidir.xml'), 'testsuite' => 'ParaTest Fixtures']);
         $loader = new SuiteLoader($options);
         $loader->load();
         $files = $this->getObjectValue($loader, 'files');
@@ -133,7 +133,7 @@ class SuiteLoaderTest extends \TestBase
     public function testLoadTestsuiteWithFilesDirsMixed()
     {
         $options = new Options(
-            array('configuration' => $this->fixture('phpunit-files-dirs-mix.xml'), 'testsuite' => 'ParaTest Fixtures')
+            ['configuration' => $this->fixture('phpunit-files-dirs-mix.xml'), 'testsuite' => 'ParaTest Fixtures']
         );
         $loader = new SuiteLoader($options);
         $loader->load();
@@ -146,7 +146,7 @@ class SuiteLoaderTest extends \TestBase
     public function testLoadTestsuiteWithNestedSuite()
     {
         $options = new Options(
-            array('configuration' => $this->fixture('phpunit-files-dirs-mix-nested.xml'), 'testsuite' => 'ParaTest Fixtures')
+            ['configuration' => $this->fixture('phpunit-files-dirs-mix-nested.xml'), 'testsuite' => 'ParaTest Fixtures']
         );
         $loader = new SuiteLoader($options);
         $loader->load();
@@ -159,7 +159,7 @@ class SuiteLoaderTest extends \TestBase
 
     public function testLoadTestsuiteWithDuplicateFilesDirMixed()
     {
-        $options = new Options(array('configuration' => $this->fixture('phpunit-files-dirs-mix-duplicates.xml'), 'testsuite' => 'ParaTest Fixtures'));
+        $options = new Options(['configuration' => $this->fixture('phpunit-files-dirs-mix-duplicates.xml'), 'testsuite' => 'ParaTest Fixtures']);
         $loader = new SuiteLoader($options);
         $loader->load();
         $files = $this->getObjectValue($loader, 'files');
@@ -170,7 +170,7 @@ class SuiteLoaderTest extends \TestBase
 
     public function testLoadSuiteFromConfig()
     {
-        $options = new Options(array('configuration' => $this->fixture('phpunit-passing.xml')));
+        $options = new Options(['configuration' => $this->fixture('phpunit-passing.xml')]);
         $loader = new SuiteLoader($options);
         $loader->load();
         $files = $this->getObjectValue($loader, 'files');
@@ -181,7 +181,7 @@ class SuiteLoaderTest extends \TestBase
 
     public function testLoadSuiteFromConfigWithMultipleDirs()
     {
-        $options = new Options(array('configuration' => $this->fixture('phpunit-multidir.xml')));
+        $options = new Options(['configuration' => $this->fixture('phpunit-multidir.xml')]);
         $loader = new SuiteLoader($options);
         $loader->load();
         $files = $this->getObjectValue($loader, 'files');
@@ -197,7 +197,7 @@ class SuiteLoaderTest extends \TestBase
      */
     public function testLoadSuiteFromConfigWithBadSuitePath()
     {
-        $options = new Options(array('configuration' => $this->fixture('phpunit-non-existent-testsuite-dir.xml')));
+        $options = new Options(['configuration' => $this->fixture('phpunit-non-existent-testsuite-dir.xml')]);
         $loader = new SuiteLoader($options);
         $loader->load();
     }
@@ -275,7 +275,7 @@ class SuiteLoaderTest extends \TestBase
 
     public function testGetTestMethodsOnlyReturnsMethodsOfGroupIfOptionIsSpecified()
     {
-        $options = new Options(array('group' => 'group1'));
+        $options = new Options(['group' => 'group1']);
         $loader = new SuiteLoader($options);
         $groupsTest = $this->fixture('passing-tests/GroupsTest.php');
         $loader->load($groupsTest);

--- a/test/unit/ParaTest/Runners/PHPUnit/SuiteTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/SuiteTest.php
@@ -6,7 +6,7 @@ class SuiteTest extends \TestBase
 
     public function setUp()
     {
-        $this->suite = new Suite('/path/to/UnitTest.php', array());
+        $this->suite = new Suite('/path/to/UnitTest.php', []);
     }
 
     public function testConstruction()

--- a/test/unit/ParaTest/Runners/PHPUnit/TestFileLoaderTest.php
+++ b/test/unit/ParaTest/Runners/PHPUnit/TestFileLoaderTest.php
@@ -8,7 +8,7 @@ class TestFileLoaderTest extends \TestBase
 {
     public function testConstructor()
     {
-        $options = new Options(array('group' => 'group1'));
+        $options = new Options(['group' => 'group1']);
         $testFileLoader = new TestFileLoader($options);
         $this->assertEquals($options, $this->getObjectValue($testFileLoader, 'options'));
     }
@@ -24,7 +24,7 @@ class TestFileLoaderTest extends \TestBase
      */
     public function testOptionsMustBeInstanceOfOptionsIfNotNull()
     {
-        $testFileLoader = new TestFileLoader(array('one' => 'two', 'three' => 'four'));
+        $testFileLoader = new TestFileLoader(['one' => 'two', 'three' => 'four']);
     }
 
     /**


### PR DESCRIPTION
As ParaTest now requires PHP>=7.0, use modern short array syntax.

Files converted using Short Array Syntax Converter:

https://github.com/thomasbachem/php-short-array-syntax-converter