### PR TITLE
Prefer splat operator over func_get_args()

### DIFF
--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -64,11 +64,8 @@ class TestBase extends PHPUnit\Framework\TestCase
      * @param mixed $args 0 or more arguments passed in the function
      * @return mixed returns what the object's method call will return
      */
-    public function call($object, $methodName, $args = null)
+    public function call($object, $methodName, ...$args)
     {
-        $args = func_get_args();
-        array_shift($args);
-        array_shift($args);
         return self::_callMethod($object, $methodName, $args);
     }
 
@@ -79,11 +76,8 @@ class TestBase extends PHPUnit\Framework\TestCase
      * @param mixed $args 0 or more arguments passed in the function
      * @return mixed returns what the object's method call will return
      */
-    public function callStatic($class, $methodName, $args = null)
+    public function callStatic($class, $methodName, ...$args)
     {
-        $args = func_get_args();
-        array_shift($args);
-        array_shift($args);
         return self::_callMethod($class, $methodName, $args);
     }
 


### PR DESCRIPTION
As ParaTest now only supports PHP >= 7.0, can safely use the splat operator instead of `func_get_args()`. The feature was introduced in PHP 5.6.

See: <https://secure.php.net/manual/en/migration56.new-features.php#migration56.new-features.splat>