### PR TITLE
fix misc minor issues noticed by Phan static analyzer

### DIFF
--- a/src/Console/Testers/PHPUnit.php
+++ b/src/Console/Testers/PHPUnit.php
@@ -29,7 +29,7 @@ class PHPUnit extends Tester
      * definitions
      *
      * @param Command $command
-     * @return mixed
+     * @return void
      */
     public function configure(Command $command)
     {

--- a/src/Logging/JUnit/TestCase.php
+++ b/src/Logging/JUnit/TestCase.php
@@ -28,7 +28,7 @@ class TestCase
     public $file;
 
     /**
-     * @var string
+     * @var int
      */
     public $line;
 
@@ -38,27 +38,39 @@ class TestCase
     public $assertions;
 
     /**
-     * @var string
+     * @var string|float (a stringified float, from phpunit XML output)
      */
     public $time;
 
     /**
-     * Number of failures in this test case
+     * List of failures in this test case
      *
      * @var array
      */
     public $failures = [];
 
     /**
-     * Number of errors in this test case
-     * TODO: Not a number?
+     * List of errors in this test case
      *
      * @var array
      */
     public $errors = [];
 
+    /**
+     * List of errors in this test case
+     *
+     * @var array
+     */
     public $skipped = [];
 
+    /**
+     * @param string $name
+     * @param string $class
+     * @param string $file
+     * @param int $line
+     * @param int $assertions
+     * @param string $time
+     */
     public function __construct(
         $name,
         $class,
@@ -151,8 +163,8 @@ class TestCase
             (string) $node['name'],
             (string) $node['class'],
             (string) $node['file'],
-            (string) $node['line'],
-            (string) $node['assertions'],
+            (int) $node['line'],
+            (int) $node['assertions'],
             (string) $node['time']
         );
 

--- a/src/Logging/JUnit/TestCase.php
+++ b/src/Logging/JUnit/TestCase.php
@@ -56,11 +56,7 @@ class TestCase
      */
     public $errors = [];
 
-    /**
-     * List of errors in this test case
-     *
-     * @var array
-     */
+    /** @var array */
     public $skipped = [];
 
     /**

--- a/src/Logging/JUnit/TestSuite.php
+++ b/src/Logging/JUnit/TestSuite.php
@@ -73,7 +73,7 @@ class TestSuite
      * @param int $failures
      * @param int $skipped
      * @param float $time
-     * @param ?string $file
+     * @param string|null $file
      */
     public function __construct(
         $name,

--- a/src/Logging/JUnit/TestSuite.php
+++ b/src/Logging/JUnit/TestSuite.php
@@ -43,7 +43,7 @@ class TestSuite
     public $skipped;
 
     /**
-     * @var string
+     * @var float
      */
     public $time;
 
@@ -66,6 +66,15 @@ class TestSuite
      */
     public $cases = [];
 
+    /**
+     * @param string $name
+     * @param int $tests
+     * @param int $assertions
+     * @param int $failures
+     * @param int $skipped
+     * @param float $time
+     * @param ?string $file
+     */
     public function __construct(
         $name,
         $tests,
@@ -90,7 +99,7 @@ class TestSuite
      * Create a TestSuite from an associative
      * array
      *
-     * @param $arr
+     * @param array $arr
      * @return TestSuite
      */
     public static function suiteFromArray($arr)
@@ -117,12 +126,12 @@ class TestSuite
     {
         return new TestSuite(
             (string) $node['name'],
-            (string) $node['tests'],
-            (string) $node['assertions'],
-            (string) $node['failures'],
-            (string) $node['errors'],
-            (string) $node['skipped'],
-            (string) $node['time'],
+            (int) $node['tests'],
+            (int) $node['assertions'],
+            (int) $node['failures'],
+            (int) $node['errors'],
+            (int) $node['skipped'],
+            (float) $node['time'],
             (string) $node['file']
         );
     }

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -58,6 +58,47 @@ class Options
     protected $filtered;
 
     /**
+     * @var string
+     */
+    protected $runner;
+
+    /**
+     * @var bool
+     */
+    protected $noTestTokens;
+
+    /**
+     * @var bool
+     */
+    protected $colors;
+
+    /**
+     * Filters which tests to run.
+     * @var ?string
+     */
+    protected $testsuite;
+
+    /**
+     * @var ?int
+     */
+    protected $maxBatchSize;
+
+    /**
+     * @var string
+     */
+    protected $filter;
+
+    /**
+     * @var string[]
+     */
+    protected $groups;
+
+    /**
+     * @var string[]
+     */
+    protected $excludeGroups;
+
+    /**
      * A collection of option values directly corresponding
      * to certain annotations - i.e group
      *
@@ -106,12 +147,24 @@ class Options
     /**
      * Public read accessibility
      *
-     * @param $var
+     * @param string $var
      * @return mixed
      */
     public function __get($var)
     {
         return $this->$var;
+    }
+
+    /**
+     * Public read accessibility
+     * (e.g. to make empty($options->property) work as expected)
+     *
+     * @param string $var
+     * @return mixed
+     */
+    public function __isset($var)
+    {
+        return isset($this->$var);
     }
 
     /**
@@ -183,7 +236,7 @@ class Options
      * @param  array $options
      * @return array
      */
-    protected function filterOptions($options)
+    protected function filterOptions(array $options) : array
     {
         $filtered = array_diff_key($options, [
             'processes' => $this->processes,

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -74,12 +74,12 @@ class Options
 
     /**
      * Filters which tests to run.
-     * @var ?string
+     * @var string|null
      */
     protected $testsuite;
 
     /**
-     * @var ?int
+     * @var int|null
      */
     protected $maxBatchSize;
 

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -233,8 +233,6 @@ class Options
     /**
      * Filter options to distinguish between paratest
      * internal options and any other options
-     * @param  array $options
-     * @return array
      */
     protected function filterOptions(array $options) : array
     {

--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -22,6 +22,11 @@ class SuiteLoader
      */
     protected $loadedSuites = [];
 
+    /**
+     * @var Options
+     */
+    public $options;
+
     public function __construct($options = null)
     {
         if ($options && !$options instanceof Options) {

--- a/src/Runners/PHPUnit/Worker.php
+++ b/src/Runners/PHPUnit/Worker.php
@@ -101,7 +101,7 @@ class Worker
             return;
         }
         $tellsUsItHasFinished = false;
-        stream_set_blocking($this->pipes[1], 1);
+        stream_set_blocking($this->pipes[1], true);
         while ($line = fgets($this->pipes[1])) {
             if (strstr($line, "FINISHED\n")) {
                 $tellsUsItHasFinished = true;
@@ -207,7 +207,7 @@ class Worker
     private function updateStateFromAvailableOutput()
     {
         if (isset($this->pipes[1])) {
-            stream_set_blocking($this->pipes[1], 0);
+            stream_set_blocking($this->pipes[1], false);
             while ($chunk = fread($this->pipes[1], 4096)) {
                 $this->chunks .= $chunk;
                 $this->alreadyReadOutput .= $chunk;
@@ -227,7 +227,7 @@ class Worker
                     $this->isRunning = false;
                 }
             }
-            stream_set_blocking($this->pipes[1], 1);
+            stream_set_blocking($this->pipes[1], true);
         }
     }
 }


### PR DESCRIPTION
- Add missing properties that were intended to be read-only
  `empty($options->filter)` was called, so added a definition of the
  magic method __isset() as well. (`empty($x->a)` is equivalent to `!isset($x->a) || !$x->a`)
- Fix inconsistencies between phpdoc and actual code.
- Add scalar type hints in phpdoc/real code
- Be specific about types parsed from phpunit xml output.
- stream_set_blocking expects bool, not int (Would be noticeable in strict mode)