### PR TITLE
Rely on PHP_BINARY to get the right executable instead of ENV

### DIFF
--- a/bin/phpunit-wrapper
+++ b/bin/phpunit-wrapper
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 echo "Worker starting\n";
 

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -182,7 +182,7 @@ abstract class ExecutableTest
     {
         $environmentVariables['PARATEST'] = 1;
         $this->handleEnvironmentVariables($environmentVariables);
-        $command = $this->command($binary, $options);
+        $command = PHP_BINARY . ' ' . $this->command($binary, $options);
         $this->assertValidCommandLineLength($command);
         $this->lastCommand = $command;
         $this->process = new Process($command, null, $environmentVariables);

--- a/src/Runners/PHPUnit/Worker.php
+++ b/src/Runners/PHPUnit/Worker.php
@@ -32,7 +32,7 @@ class Worker
         if ($uniqueToken) {
             $bin .= "UNIQUE_TEST_TOKEN=$uniqueToken ";
         }
-        $bin .= "exec \"$wrapperBinary\"";
+        $bin .= PHP_BINARY . " \"$wrapperBinary\"";
         $pipes = [];
         $this->proc = proc_open($bin, self::$descriptorspec, $pipes);
         $this->pipes = $pipes;

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -40,7 +40,7 @@ class ParaTestInvoker
 
     private function buildCommand($options=[])
     {
-        $cmd = sprintf("%s --bootstrap %s --phpunit %s", PARA_BINARY, $this->bootstrap, PHPUNIT);
+        $cmd = sprintf("%s %s --bootstrap %s --phpunit %s", PHP_BINARY, PARA_BINARY, $this->bootstrap, PHPUNIT);
         foreach($options as $switch => $value) {
             if(is_numeric($switch)) {
                 $switch = $value;


### PR DESCRIPTION
Both `phpunit-wrapper` and `phpunit` rely on `#!/usr/bin/env php` hashbash to detect the php executable.
This can be not found in the `$PATH`, or a user can start paratest with a different php than the one of the path (for ex. with a command like `/my/custom/build/php vendor/bin/paratest`.

Relying on `PHP_BINARY` to execute both the script is the only solution.

I tried to make a test for this bug, but cannot find the way to disable Travis environment.