### PR TITLE
Travis build refactored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,44 @@ language: php
 
 sudo: false
 
-dist: trusty
-
-# hhvm won't work with phpunit 6.x due to lack of Throwable support, see https://github.com/facebook/hhvm/issues/6037
-php:
-    - 7.0
-    - 7.1
-
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/
 
 matrix:
   fast_finish: true
+  include:
+    - php: 7
+      env:
+        - DEPS=lowest
+    - php: 7
+      env:
+        - CODE_COVERAGE=true
+    - php: 7
+      env:
+        - CS_CHECK=true
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+    - php: 7.1
+      env:
+        - PHPUNIT_DEV=true
+    - php: nightly
   allow_failures:
-    - env: PHPUNIT_VERSION='*@dev'
+    - php: nightly
 
-env:
-    - PHPUNIT_VERSION='6.0.*@stable'
-    - PHPUNIT_VERSION='6.*@stable'
-    - PHPUNIT_VERSION='*@dev'
-
-before_script:
-    - composer require --no-update phpunit/phpunit=$PHPUNIT_VERSION
-    - composer install --prefer-dist
+install:
+  - if [[ $CS_CHECK == 'true' ]]; then phpenv config-rm xdebug.ini || return 0; else composer remove --dev --no-update --no-scripts friendsofphp/php-cs-fixer; fi;
+  - if [[ $PHPUNIT_DEV == 'true' ]]; then composer require --no-update phpunit/phpunit=*@dev; fi;
+  - if [[ $DEPS == 'lowest' ]]; then COMPOSER_ARGS='--prefer-lowest --prefer-stable'; fi; composer update --no-interaction --prefer-dist $COMPOSER_ARGS
 
 script:
-    - vendor/bin/phpunit --coverage-clover=coverage.clover
-    - if [[ $TRAVIS_PHP_VERSION == "7.0" && $PHPUNIT_VERSION == '6.*@stable' ]]; then vendor/bin/php-cs-fixer fix --diff --dry-run --verbose ; fi
+  - if [[ $CS_CHECK == 'true' ]]; then vendor/bin/php-cs-fixer fix --diff --dry-run --verbose; fi;
+  - if [[ $CS_CHECK != 'true' ]]; then if [[ $CODE_COVERAGE == 'true' ]]; then COVERAGE_ARGS='--coverage-clover=coverage.clover'; fi; vendor/bin/phpunit $COVERAGE_ARGS; fi;
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [[ $CODE_COVERAGE == 'true' ]]; then wget https://scrutinizer-ci.com/ocular.phar; php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi;
+
+notifications:
+  email: false

--- a/composer.json
+++ b/composer.json
@@ -2,15 +2,15 @@
     "name": "brianium/paratest",
     "require": {
         "php": ">=7.0",
-        "phpunit/phpunit": "~6.0",
-        "phpunit/php-timer": "^1.0.4",
-        "symfony/console": "~2.3|~3.0",
-        "symfony/process": "~2.3|~3.0",
-        "brianium/habitat": "1.0.0",
+        "ext-pcre": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "ext-pcre": "*",
-        "composer/semver": "~1.2"
+        "brianium/habitat": "1.0.0",
+        "composer/semver": "~1.2",
+        "phpunit/php-timer": "^1.0.4",
+        "phpunit/phpunit": "^6.0.13",
+        "symfony/console": "^3.0",
+        "symfony/process": "^3.0"
     },
     "type": "library",
     "description": "Parallel testing for PHP",


### PR DESCRIPTION
Hi, I've refactored the Travis build with the following changes:

1. Dependencies are now installed on lowest or latest version; this is mandatory because if a version is allowed we need to test it
1. PHPUnit is now pinned to ^6.0.13 because there are some issues with intermediate minor versions, never tested before this PR and point 1 got emerged
1. Symfony is now pinned to ^3.0 for the same reason, Travis fails with Symfony ~2.0 but previous Travis config didn't show it
1. Code Coverage is done in one build only, on the lowest PHP Version but with the latest dependencies; an ENV variable is set to be clear on the build
1. CS Fixes are checked on an own build without tests involved; an ENV variable is set to be clear on the build
1. PHP 7.2 is now tested, but allowed to fail
1. PHPUnit@dev is tested on latest PHP only to reduce build matrix