### PR TITLE
declare(strict_types=1);

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,6 +9,7 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'combine_consecutive_unsets' => true,
         'concat_space' => ['spacing' => 'one'],
+        'declare_strict_types' => true,
         'heredoc_to_nowdoc' => true,
         'list_syntax' => ['syntax' => 'long'],
         'method_argument_space' => true,

--- a/src/Console/Commands/ParaTestCommand.php
+++ b/src/Console/Commands/ParaTestCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Console\Commands;
 
 use Composer\Semver\Comparator;

--- a/src/Console/ParaTestApplication.php
+++ b/src/Console/ParaTestApplication.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Console;
 
 use ParaTest\Console\Commands\ParaTestCommand;

--- a/src/Console/Testers/PHPUnit.php
+++ b/src/Console/Testers/PHPUnit.php
@@ -71,7 +71,7 @@ class PHPUnit extends Tester
                 // because we want to have to bootstrap script inherited before check/initialization
                 $runnerOption = $this->getRunnerOptions($input);
                 $runnerClass = $input->getOption('runner');
-                if (class_exists($runnerClass)) {
+                if (null !== $runnerClass && class_exists($runnerClass)) {
                     $runner = new $runnerClass($runnerOption);
                 }
             }

--- a/src/Console/Testers/PHPUnit.php
+++ b/src/Console/Testers/PHPUnit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Console\Testers;
 
 use ParaTest\Runners\PHPUnit\Configuration;

--- a/src/Console/Testers/Tester.php
+++ b/src/Console/Testers/Tester.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Console\Testers;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Coverage/CoverageMerger.php
+++ b/src/Coverage/CoverageMerger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Coverage;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;

--- a/src/Coverage/CoverageReporter.php
+++ b/src/Coverage/CoverageReporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Coverage;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;

--- a/src/Coverage/CoverageReporterInterface.php
+++ b/src/Coverage/CoverageReporterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Coverage;
 
 interface CoverageReporterInterface

--- a/src/Logging/JUnit/Reader.php
+++ b/src/Logging/JUnit/Reader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging\JUnit;
 
 use ParaTest\Logging\MetaProvider;

--- a/src/Logging/JUnit/TestCase.php
+++ b/src/Logging/JUnit/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging\JUnit;
 
 /**

--- a/src/Logging/JUnit/TestSuite.php
+++ b/src/Logging/JUnit/TestSuite.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging\JUnit;
 
 /**

--- a/src/Logging/JUnit/Writer.php
+++ b/src/Logging/JUnit/Writer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging\JUnit;
 
 use ParaTest\Logging\LogInterpreter;

--- a/src/Logging/JUnit/Writer.php
+++ b/src/Logging/JUnit/Writer.php
@@ -118,7 +118,7 @@ class Writer
         $vars = get_object_vars($suite);
         foreach ($vars as $name => $value) {
             if (preg_match(static::$suiteAttrs, $name)) {
-                $suiteNode->setAttribute($name, $value);
+                $suiteNode->setAttribute($name, (string) $value);
             }
         }
         $root->appendChild($suiteNode);
@@ -144,7 +144,7 @@ class Writer
                 if ($this->isEmptyLineAttribute($name, $value)) {
                     continue;
                 }
-                $caseNode->setAttribute($name, $value);
+                $caseNode->setAttribute($name, (string) $value);
             }
         }
         $suiteNode->appendChild($caseNode);
@@ -187,7 +187,7 @@ class Writer
         $rootSuite = $this->document->createElement('testsuite');
         $attrs = $this->getSuiteRootAttributes($suites);
         foreach ($attrs as $attr => $value) {
-            $rootSuite->setAttribute($attr, $value);
+            $rootSuite->setAttribute($attr, (string) $value);
         }
         $testsuites->appendChild($rootSuite);
 

--- a/src/Logging/LogInterpreter.php
+++ b/src/Logging/LogInterpreter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging;
 
 use ParaTest\Logging\JUnit\Reader;

--- a/src/Logging/MetaProvider.php
+++ b/src/Logging/MetaProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging;
 
 /**

--- a/src/Parser/NoClassInFileException.php
+++ b/src/Parser/NoClassInFileException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 class NoClassInFileException extends \Exception

--- a/src/Parser/ParsedClass.php
+++ b/src/Parser/ParsedClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 class ParsedClass extends ParsedObject

--- a/src/Parser/ParsedFunction.php
+++ b/src/Parser/ParsedFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 class ParsedFunction extends ParsedObject

--- a/src/Parser/ParsedObject.php
+++ b/src/Parser/ParsedObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 abstract class ParsedObject

--- a/src/Parser/ParsedObject.php
+++ b/src/Parser/ParsedObject.php
@@ -60,6 +60,6 @@ abstract class ParsedObject
             null !== $value ? "[\s]+$value" : '\b'
         );
 
-        return (bool) preg_match($pattern, $this->docBlock);
+        return false !== $this->docBlock && 1 === preg_match($pattern, $this->docBlock);
     }
 }

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -92,7 +92,8 @@ class Parser
         $methods = $this->refl->getMethods(\ReflectionMethod::IS_PUBLIC);
         foreach ($methods as $method) {
             $hasTestName = preg_match(self::$testName, $method->getName());
-            $hasTestAnnotation = preg_match(self::$testAnnotation, $method->getDocComment());
+            $docComment = $method->getDocComment();
+            $hasTestAnnotation = false !== $docComment && preg_match(self::$testAnnotation, $docComment);
             $isTestMethod = $hasTestName || $hasTestAnnotation;
             if ($isTestMethod) {
                 $tests[] = new ParsedFunction($method->getDocComment(), 'public', $method->getName());

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 class Parser

--- a/src/Runners/PHPUnit/BaseRunner.php
+++ b/src/Runners/PHPUnit/BaseRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use ParaTest\Coverage\CoverageMerger;

--- a/src/Runners/PHPUnit/Configuration.php
+++ b/src/Runners/PHPUnit/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 /**

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use Symfony\Component\Process\Process;

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -138,7 +138,7 @@ class Options
                              ? explode(',', $opts['exclude-group'])
                              : [];
 
-        if (strlen($opts['filter']) > 0 && !$this->functional) {
+        if (isset($opts['filter']) && strlen($opts['filter']) > 0 && !$this->functional) {
             throw new \RuntimeException('Option --filter is not implemented for non functional mode');
         }
 

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 /**

--- a/src/Runners/PHPUnit/ResultPrinter.php
+++ b/src/Runners/PHPUnit/ResultPrinter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use ParaTest\Logging\JUnit\Reader;

--- a/src/Runners/PHPUnit/Runner.php
+++ b/src/Runners/PHPUnit/Runner.php
@@ -138,7 +138,7 @@ class Runner extends BaseRunner
     {
         $this->tokens = [];
         for ($i = 0; $i < $this->options->processes; ++$i) {
-            $this->tokens[$i] = ['token' => $i, 'unique' => uniqid($i), 'available' => true];
+            $this->tokens[$i] = ['token' => $i, 'unique' => uniqid(sprintf('%s_', $i)), 'available' => true];
         }
     }
 

--- a/src/Runners/PHPUnit/Runner.php
+++ b/src/Runners/PHPUnit/Runner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use Habitat\Habitat;

--- a/src/Runners/PHPUnit/Suite.php
+++ b/src/Runners/PHPUnit/Suite.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 /**

--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -285,21 +285,21 @@ class SuiteLoader
 
     private function methodDataProvider($method)
     {
-        if (preg_match("/@\bdataProvider\b \b(.*)\b/", $method->getDocBlock(), $matches)) {
+        if (false !== ($docBlock = $method->getDocBlock()) && preg_match("/@\bdataProvider\b \b(.*)\b/", $docBlock, $matches)) {
             return $matches[1];
         }
     }
 
     private function methodDependency($method)
     {
-        if (preg_match("/@\bdepends\b \b(.*)\b/", $method->getDocBlock(), $matches)) {
+        if (false !== ($docBlock = $method->getDocBlock()) && preg_match("/@\bdepends\b \b(.*)\b/", $docBlock, $matches)) {
             return $matches[1];
         }
     }
 
     private function methodGroups($method)
     {
-        if (preg_match_all("/@\bgroup\b \b(.*)\b/", $method->getDocBlock(), $matches)) {
+        if (false !== ($docBlock = $method->getDocBlock()) && preg_match_all("/@\bgroup\b \b(.*)\b/", $docBlock, $matches)) {
             return $matches[1];
         }
 

--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use ParaTest\Parser\NoClassInFileException;

--- a/src/Runners/PHPUnit/SuitePath.php
+++ b/src/Runners/PHPUnit/SuitePath.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 /**

--- a/src/Runners/PHPUnit/TestFileLoader.php
+++ b/src/Runners/PHPUnit/TestFileLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 class TestFileLoader

--- a/src/Runners/PHPUnit/TestMethod.php
+++ b/src/Runners/PHPUnit/TestMethod.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 /**

--- a/src/Runners/PHPUnit/Worker.php
+++ b/src/Runners/PHPUnit/Worker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use Exception;

--- a/src/Runners/PHPUnit/WrapperRunner.php
+++ b/src/Runners/PHPUnit/WrapperRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 class WrapperRunner extends BaseRunner

--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 use PHPUnit\Runner\Version;
 use SebastianBergmann\Environment\Runtime;
 
@@ -28,10 +29,11 @@ class TestBase extends PHPUnit\Framework\TestCase
 
     protected function findTests($dir)
     {
+        $it = new \RecursiveDirectoryIterator($dir, \RecursiveIteratorIterator::SELF_FIRST);
+        $it = new \RecursiveIteratorIterator($it);
         $files = [];
-        foreach (new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($dir, \RecursiveIteratorIterator::SELF_FIRST)) as $file) {
-            if (preg_match('/Test\.php$/', $file)) {
+        foreach ($it as $file) {
+            if (preg_match('/Test\.php$/', $file->getPathname())) {
                 $files[] = $file;
             }
         }

--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 use PHPUnit\Runner\Version;
 use SebastianBergmann\Environment\Runtime;
 

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
 }

--- a/test/functional/Coverage/CoverageMergerTest.php
+++ b/test/functional/Coverage/CoverageMergerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 use ParaTest\Coverage\CoverageMerger;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 

--- a/test/functional/Coverage/CoverageMergerTest.php
+++ b/test/functional/Coverage/CoverageMergerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 use ParaTest\Coverage\CoverageMerger;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 

--- a/test/functional/Coverage/CoverageReporterTest.php
+++ b/test/functional/Coverage/CoverageReporterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 use ParaTest\Coverage\CoverageMerger;
 use ParaTest\Coverage\CoverageReporter;
 

--- a/test/functional/Coverage/CoverageReporterTest.php
+++ b/test/functional/Coverage/CoverageReporterTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 use ParaTest\Coverage\CoverageMerger;
 use ParaTest\Coverage\CoverageReporter;
 

--- a/test/functional/DataProviderTest.php
+++ b/test/functional/DataProviderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 class DataProviderTest extends FunctionalTestBase
 {
     /** @var ParatestInvoker */

--- a/test/functional/DataProviderTest.php
+++ b/test/functional/DataProviderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 class DataProviderTest extends FunctionalTestBase
 {
     /** @var ParatestInvoker */

--- a/test/functional/EmptyRunnerStub.php
+++ b/test/functional/EmptyRunnerStub.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 class EmptyRunnerStub extends \ParaTest\Runners\PHPUnit\BaseRunner
 {
     public function run()

--- a/test/functional/EmptyRunnerStub.php
+++ b/test/functional/EmptyRunnerStub.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 class EmptyRunnerStub extends \ParaTest\Runners\PHPUnit\BaseRunner
 {
     public function run()

--- a/test/functional/FunctionalTestBase.php
+++ b/test/functional/FunctionalTestBase.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 use \Symfony\Component\Process\Process;
 
 class FunctionalTestBase extends PHPUnit\Framework\TestCase

--- a/test/functional/FunctionalTestBase.php
+++ b/test/functional/FunctionalTestBase.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 use \Symfony\Component\Process\Process;
 
 class FunctionalTestBase extends PHPUnit\Framework\TestCase

--- a/test/functional/GroupTest.php
+++ b/test/functional/GroupTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 class GroupTest extends FunctionalTestBase
 {
     /** @var ParatestInvoker */

--- a/test/functional/GroupTest.php
+++ b/test/functional/GroupTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 class GroupTest extends FunctionalTestBase
 {
     /** @var ParatestInvoker */

--- a/test/functional/OutputTest.php
+++ b/test/functional/OutputTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 class OutputTest extends FunctionalTestBase
 {
     public function setUp()

--- a/test/functional/OutputTest.php
+++ b/test/functional/OutputTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 class OutputTest extends FunctionalTestBase
 {
     public function setUp()

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 class PHPUnitTest extends FunctionalTestBase
 {
     public function testWithJustBootstrap()

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 class PHPUnitTest extends FunctionalTestBase
 {
     public function testWithJustBootstrap()

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * Specifically tests warnings in PHPUnit.
  */

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * Specifically tests warnings in PHPUnit.
  */

--- a/test/functional/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
+++ b/test/functional/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use ParaTest\Console\Commands\ParaTestCommand;

--- a/test/functional/ParaTest/Runners/PHPUnit/WorkerTest.php
+++ b/test/functional/ParaTest/Runners/PHPUnit/WorkerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use SimpleXMLElement;

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 use \Habitat\Habitat;
 use \Symfony\Component\Process\Process;
 

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 use \Habitat\Habitat;
 use \Symfony\Component\Process\Process;
 

--- a/test/functional/ProcessCallback.php
+++ b/test/functional/ProcessCallback.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 class ProcessCallback
 {
     protected $type;

--- a/test/functional/ProcessCallback.php
+++ b/test/functional/ProcessCallback.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 class ProcessCallback
 {
     protected $type;

--- a/test/functional/SkippedOrIncompleteTest.php
+++ b/test/functional/SkippedOrIncompleteTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * @todo SkippedOrIncompleteTest can't be used in default mode with group filter
  *       (not implemented yet) so we have to split tests per file.

--- a/test/functional/SkippedOrIncompleteTest.php
+++ b/test/functional/SkippedOrIncompleteTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * @todo SkippedOrIncompleteTest can't be used in default mode with group filter
  *       (not implemented yet) so we have to split tests per file.

--- a/test/functional/TestGenerator.php
+++ b/test/functional/TestGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 class TestGenerator
 {
     public $path;

--- a/test/functional/TestGenerator.php
+++ b/test/functional/TestGenerator.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 class TestGenerator
 {
     public $path;

--- a/test/functional/WrapperRunnerTest.php
+++ b/test/functional/WrapperRunnerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 class WrapperRunnerTest extends FunctionalTestBase
 {
     const TEST_METHODS_PER_CLASS = 5;

--- a/test/functional/WrapperRunnerTest.php
+++ b/test/functional/WrapperRunnerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 class WrapperRunnerTest extends FunctionalTestBase
 {
     const TEST_METHODS_PER_CLASS = 5;

--- a/test/unit/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/Console/Commands/ParaTestCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Console\Commands;
 
 use ParaTest\Console\Testers\PHPUnit;

--- a/test/unit/Console/Testers/PHPUnitTest.php
+++ b/test/unit/Console/Testers/PHPUnitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Console\Testers;
 
 use Symfony\Component\Console\Command\Command;

--- a/test/unit/Coverage/CoverageMergerTest.php
+++ b/test/unit/Coverage/CoverageMergerTest.php
@@ -24,6 +24,8 @@ class CoverageMergerTest extends \TestBase
         $firstFile = PARATEST_ROOT . '/src/Logging/LogInterpreter.php';
         $secondFile = PARATEST_ROOT . '/src/Logging/MetaProvider.php';
 
+        // Every time the two above files are changed, the line numbers
+        // may change, and so these two numbers may need adjustments
         $firstFileFirstLine = 38;
         $secondFileFirstLine = 38;
 

--- a/test/unit/Coverage/CoverageMergerTest.php
+++ b/test/unit/Coverage/CoverageMergerTest.php
@@ -24,8 +24,8 @@ class CoverageMergerTest extends \TestBase
         $firstFile = PARATEST_ROOT . '/src/Logging/LogInterpreter.php';
         $secondFile = PARATEST_ROOT . '/src/Logging/MetaProvider.php';
 
-        $firstFileFirstLine = 36;
-        $secondFileFirstLine = 36;
+        $firstFileFirstLine = 38;
+        $secondFileFirstLine = 38;
 
         $filter = new Filter();
         $filter->addFilesToWhitelist([$firstFile, $secondFile]);

--- a/test/unit/Coverage/CoverageMergerTest.php
+++ b/test/unit/Coverage/CoverageMergerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Coverage;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;

--- a/test/unit/Logging/JUnit/ReaderTest.php
+++ b/test/unit/Logging/JUnit/ReaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging\JUnit;
 
 use PHPUnit\Framework\ExpectationFailedException;

--- a/test/unit/Logging/JUnit/WriterTest.php
+++ b/test/unit/Logging/JUnit/WriterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging\JUnit;
 
 use ParaTest\Logging\LogInterpreter;

--- a/test/unit/Logging/LogInterpreterTest.php
+++ b/test/unit/Logging/LogInterpreterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Logging;
 
 use ParaTest\Logging\JUnit\Reader;

--- a/test/unit/Parser/ParsedClassTest.php
+++ b/test/unit/Parser/ParsedClassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 class ParsedClassTest extends \TestBase

--- a/test/unit/Parser/ParsedObjectTest.php
+++ b/test/unit/Parser/ParsedObjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 class ParsedObjectTest extends \TestBase

--- a/test/unit/Parser/ParserTest.php
+++ b/test/unit/Parser/ParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 class ParserTest extends \TestBase

--- a/test/unit/Parser/ParserTest/GetClassTest.php
+++ b/test/unit/Parser/ParserTest/GetClassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Parser;
 
 class GetClassTest extends \TestBase

--- a/test/unit/ResultTester.php
+++ b/test/unit/ResultTester.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest;
 
 use ParaTest\Parser\ParsedFunction;

--- a/test/unit/Runners/PHPUnit/ConfigurationTest.php
+++ b/test/unit/Runners/PHPUnit/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 class ConfigurationTest extends \TestBase

--- a/test/unit/Runners/PHPUnit/ExecutableTestTest.php
+++ b/test/unit/Runners/PHPUnit/ExecutableTestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 class ExecutableTestTest extends \TestBase

--- a/test/unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/unit/Runners/PHPUnit/OptionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 class OptionsTest extends \TestBase

--- a/test/unit/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/unit/Runners/PHPUnit/ResultPrinterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use ParaTest\Logging\LogInterpreter;

--- a/test/unit/Runners/PHPUnit/RunnerTest.php
+++ b/test/unit/Runners/PHPUnit/RunnerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 use ParaTest\Logging\LogInterpreter;

--- a/test/unit/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/unit/Runners/PHPUnit/SuiteLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 class SuiteLoaderTest extends \TestBase

--- a/test/unit/Runners/PHPUnit/SuiteTest.php
+++ b/test/unit/Runners/PHPUnit/SuiteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 class SuiteTest extends \TestBase

--- a/test/unit/Runners/PHPUnit/TestFileLoaderTest.php
+++ b/test/unit/Runners/PHPUnit/TestFileLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 /**

--- a/test/unit/Runners/PHPUnit/TestMethodTest.php
+++ b/test/unit/Runners/PHPUnit/TestMethodTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ParaTest\Runners\PHPUnit;
 
 class TestMethodTest extends \TestBase


### PR DESCRIPTION
- [x] Add `declare_strict_types` fixer
- [x] Apply fix
- [x] Fix new strict errors
- [x] **Zero** test changed

Closes https://github.com/brianium/paratest/issues/252, but a new PR with added `type hints` and `return types` should be created.