### PR TITLE
Update symfony dep to ^3.2, automatically inherit env variables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "composer/semver": "~1.2",
         "phpunit/php-timer": "^1.0.4",
         "phpunit/phpunit": "^6.0.13",
-        "symfony/console": "^3.0",
-        "symfony/process": "^3.0"
+        "symfony/console": "^3.2",
+        "symfony/process": "^3.2"
     },
     "type": "library",
     "description": "Parallel testing for PHP",

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -192,6 +192,9 @@ abstract class ExecutableTest
         $this->assertValidCommandLineLength($command);
         $this->lastCommand = $command;
         $this->process = new Process($command, null, $environmentVariables);
+        if (method_exists($this->process, 'inheritEnvironmentVariables')) {
+            $this->process->inheritEnvironmentVariables();  // no such method in 3.0, but emits warning if this isn't done in 3.3
+        }
         $this->process->start();
 
         return $this;

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -29,6 +29,9 @@ class ParaTestInvoker
         $cmd = $this->buildCommand($options);
         $env = defined('PHP_WINDOWS_VERSION_BUILD') ? Habitat::getAll() : null;
         $proc = new Process($cmd, null, $env, null, $timeout = 600);
+        if (method_exists($proc, 'inheritEnvironmentVariables')) {
+            $proc->inheritEnvironmentVariables();  // no such method in 3.0, but emits warning if this isn't done in 3.3
+        }
 
         if (!is_callable($callback)) {
             $proc->run();


### PR DESCRIPTION
This may break assumptions in some projects about the way
paratest sets up environment variables.
(I think it might clear some of them, which differs from phpunit?)

Symfony 3.3 has deprecated the old behavior, which will be removed
eventually in 4.0.
(Saw this E_USER_DEPRECATED warning in a different project with a
different error_handler callback)

Symfony/console versions 3.0-3.1 don't implement inheritEnvironmentVariables

- To be consistent about environment variables, require a minimum of 3.2
- 3.0-3.1 are about to stop being supported
  https://symfony.com/roadmap?version=3.1#checker
- Keep the method_exists check for now, just in case 

See https://github.com/symfony/process/blob/3.3/Process.php#L319