### PR TITLE
Remove leading backslash from use statements

### DIFF
--- a/test/functional/FunctionalTestBase.php
+++ b/test/functional/FunctionalTestBase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use \Symfony\Component\Process\Process;
+use Symfony\Component\Process\Process;
 
 class FunctionalTestBase extends PHPUnit\Framework\TestCase
 {

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use \Habitat\Habitat;
-use \Symfony\Component\Process\Process;
+use Habitat\Habitat;
+use Symfony\Component\Process\Process;
 
 class ParaTestInvoker
 {


### PR DESCRIPTION
Move conventional and inline with PHP recommendations.

From the PHP documentation:

http://php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing

> Note that for namespaced names …, the leading backslash is unnecessary
> and not recommended, as import names must be fully qualified, and are
> not processed relative to the current namespace.