### PR TITLE
Fix version reporting in console, closes #257

### DIFF
--- a/src/Console/ParaTestApplication.php
+++ b/src/Console/ParaTestApplication.php
@@ -19,7 +19,7 @@ class ParaTestApplication extends Application
 
     public function __construct()
     {
-        parent::__construct(static::NAME, static::VERSION);
+        parent::__construct(static::NAME, VersionProvider::getVersion(static::VERSION));
     }
 
     /**

--- a/src/Console/VersionProvider.php
+++ b/src/Console/VersionProvider.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Console;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Class VersionProvider.
+ *
+ * Obtain version information of the ParaTest application itself based on
+ * it's current installment (composer; git; default passed)
+ */
+final class VersionProvider
+{
+    const PACKAGE = 'brianium/paratest';
+    /**
+     * @var null
+     */
+    private $default;
+
+    public function __construct($default = null)
+    {
+        $this->default = $default;
+    }
+
+    public static function getVersion($default = null)
+    {
+        $provider = new self($default);
+
+        return $provider->getParaTestVersion();
+    }
+
+    public function getParaTestVersion()
+    {
+        return $this->getComposerInstalledVersion(self::PACKAGE)
+            ?? $this->getGitVersion()
+            ?? $this->default;
+    }
+
+    public function getGitVersion()
+    {
+        $version = null;
+
+        $process = new Process('git describe --tags --always --first-parent', __DIR__);
+        if ($process->run() !== 0) {
+            return;
+        }
+        $version = trim($process->getOutput());
+
+        return $version;
+    }
+
+    public function getComposerInstalledVersion($package)
+    {
+        if (null === $path = $this->getComposerInstalledJsonPath()) {
+            return;
+        }
+
+        $result = file_get_contents($path);
+        if (false === $result) {
+            return;
+        }
+
+        $struct = json_decode($result, true, 16);
+        if (!is_array($struct)) {
+            return;
+        }
+
+        foreach ($struct as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $name = $entry['name'] ?? null;
+            if (null === $name || $name !== $package) {
+                continue;
+            }
+            $version = $entry['version'] ?? null;
+            if (null === $version) {
+                continue;
+            }
+
+            return $version;
+        }
+    }
+
+    /**
+     * @return string|null path to composer/installed.json
+     */
+    private function getComposerInstalledJsonPath()
+    {
+        $paths = [
+            // path in the installed version
+            __DIR__ . '/../../../../composer/installed.json',
+            // path in the source version
+            __DIR__ . '/../../vendor/composer/installed.json',
+        ];
+
+        // first hit makes it
+        foreach ($paths as $path) {
+            if (file_exists($path) && is_readable($path)) {
+                return $path;
+            }
+        }
+    }
+}

--- a/test/unit/Console/VersionProviderTest.php
+++ b/test/unit/Console/VersionProviderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Console;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class VersionProviderTest.
+ *
+ * @covers \ParaTest\Console\VersionProvider
+ */
+class VersionProviderTest extends TestCase
+{
+    public function testCreation()
+    {
+        $provider = new VersionProvider();
+        $this->assertInstanceOf(VersionProvider::class, $provider);
+    }
+
+    public function testStaticCall()
+    {
+        $provider = new VersionProvider();
+        $this->assertSame($provider::getVersion(), $provider->getParaTestVersion());
+    }
+
+    public function testComposerInstalledVersion()
+    {
+        $provider = new VersionProvider();
+        $actual = $provider->getComposerInstalledVersion('phpunit/phpunit');
+        $this->assertInternalType('string', $actual, 'Version of phpunit package was found installed');
+
+        // dev-master is included here as the phpunit package is checked and there is a dev-master used on travis
+        $this->assertRegExp("~^dev-master|\d.\d.\d+$~", $actual, 'Actual version number');
+
+        $actual = $provider->getComposerInstalledVersion('foooo/barazzoraz');
+        $this->assertNull($actual, 'No version for non-existent package');
+    }
+
+    public function testGitVersion()
+    {
+        $provider = new VersionProvider();
+        $actual = $provider->getGitVersion();
+        $this->assertInternalType('string', $actual, 'Git is enabled and works');
+        $this->assertRegExp("~^\d.\d.\d+(?:-\d+-g[\da-f]+)?$~", $actual, 'Git gives a version');
+    }
+}


### PR DESCRIPTION
ParaTest has the version number hard-encoded.

Previously when reporting the version via --version that hard-encoded
version number was presented in the output (e.g. 1.0.1).

As technically the version changes with git commit and not every git
commit is tagged and not even every tagged commit contains the appropriate
change to the hard-encoded version number within

    \ParaTest\Console\ParaTestApplication::VERSION

the wrong version is reported.

This commit addresses the issue by first looking up the installed version
of the package "brianium/paratest" from within composer's installed.json
file which contains the currently installed version (based on the git tag,
see Packagist) and if not found (e.g. you have checked out the development
version in a git clone) the version number will be taken from git directly.

If everything of these look-ups fail, the fallback is to the current
behavior of taking the version from the constant.

Refs:

- #257