### PR TITLE
README.md: add code-coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ ParaTest
 ========
 
 [![Build Status](https://travis-ci.org/brianium/paratest.svg?branch=master)](https://travis-ci.org/brianium/paratest)
+[![Code Coverage](https://scrutinizer-ci.com/g/brianium/paratest/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/brianium/paratest/?branch=master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/brianium/paratest/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/brianium/paratest/?branch=master)
 [![Packagist](https://img.shields.io/packagist/dt/brianium/paratest.svg)](https://packagist.org/packages/brianium/paratest)
 


### PR DESCRIPTION
I consider CC an info with higher priority of scrutinizer score.