### PR TITLE
Suggest enabling xdebug for coverage

### DIFF
--- a/src/Coverage/CoverageMerger.php
+++ b/src/Coverage/CoverageMerger.php
@@ -61,7 +61,7 @@ class CoverageMerger
         if (0 === $file->getSize()) {
             $extra = 'This means a PHPUnit process has crashed.';
 
-            if (!function_exists("xdebug_get_code_coverage")) {
+            if (!function_exists('xdebug_get_code_coverage')) {
                 $extra = 'Xdebug is disabled! Enable for coverage.';
             }
 

--- a/src/Coverage/CoverageMerger.php
+++ b/src/Coverage/CoverageMerger.php
@@ -59,8 +59,14 @@ class CoverageMerger
         $file = new \SplFileObject($coverageFile);
 
         if (0 === $file->getSize()) {
+            $extra = 'This means a PHPUnit process has crashed.';
+
+            if (!function_exists("xdebug_get_code_coverage")) {
+                $extra = 'Xdebug is disabled! Enable for coverage.';
+            }
+
             throw new \RuntimeException(
-                "Coverage file {$file->getRealPath()} is empty. This means a PHPUnit process has crashed."
+                "Coverage file {$file->getRealPath()} is empty. " . $extra
             );
         }
 


### PR DESCRIPTION
When xdebug is disabled, the message why paratest fails is a bit cryptic.

This PR adds a check to see if xdebug is enabled and changes the message to be more specific if it's disabled/missing.

Related to #158