### PR TITLE
Symfony 4 compatibility

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -36,6 +36,7 @@ return PhpCsFixer\Config::create()
         'simplified_null_return' => true,
         'strict_comparison' => true,
         'strict_param' => true,
+        'yoda_style' => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,11 @@
         "composer/semver": "~1.2",
         "phpunit/php-timer": "^1.0.4",
         "phpunit/phpunit": "^6.0.13",
-        "symfony/console": "^3.2",
-        "symfony/process": "^3.2"
+        "symfony/console": "^3.2|^4.0",
+        "symfony/process": "^3.2|^4.0"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.3.2"
     },
     "type": "library",
     "description": "Parallel testing for PHP",
@@ -38,8 +41,5 @@
         "psr-4": {
             "ParaTest\\": "test/unit/"
         }
-    },
-    "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.3.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "composer/semver": "~1.2",
         "phpunit/php-timer": "^1.0.4",
         "phpunit/phpunit": "^6.0.13",
-        "symfony/console": "^3.2|^4.0",
-        "symfony/process": "^3.2|^4.0"
+        "symfony/console": "^3.4|^4.0",
+        "symfony/process": "^3.4|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.3.2"

--- a/src/Runners/PHPUnit/Configuration.php
+++ b/src/Runners/PHPUnit/Configuration.php
@@ -134,7 +134,7 @@ class Configuration
                                     unset($excludedPaths[$dir]);
                                 }
                             }
-                            // not breaking on purpose
+                            // no break on purpose
                         default:
                             foreach ($this->getSuitePaths((string) $nodeContent) as $path) {
                                 $suites[(string) $node['name']][] = new SuitePath(

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -279,10 +279,12 @@ abstract class ExecutableTest
                 throw new \RuntimeException('Command line is too long, try to decrease max batch size');
             }
         }
-            // TODO: Implement command line length validation for linux/osx/freebsd
-            //       Please note that on unix environment variables also became part of command line
-            // linux: echo | xargs --show-limits
-            // osx/linux: getconf ARG_MAX
+        /*
+         * @todo Implement command line length validation for linux/osx/freebsd.
+         *       Please note that on unix environment variables also became part of command line:
+         *         - linux: echo | xargs --show-limits
+         *         - osx/linux: getconf ARG_MAX
+         */
     }
 
     /**
@@ -319,7 +321,6 @@ abstract class ExecutableTest
 
         $arguments[] = $this->fullyQualifiedClassName ?? '';
         $arguments[] = $this->getPath();
-
 
         return (new Process($arguments))->getCommandLine();
     }

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ParaTest\Runners\PHPUnit;
 
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessBuilder;
 
 abstract class ExecutableTest
 {
@@ -302,28 +301,27 @@ abstract class ExecutableTest
      * Returns the command string that will be executed
      * by proc_open.
      *
-     * @param $binary
-     * @param array $options
+     * @param string $binary
+     * @param array  $options
      *
      * @return mixed
      */
     protected function getCommandString(string $binary, array $options = [])
     {
-        $builder = new ProcessBuilder();
-        $builder->setPrefix($binary);
+        // The order we add stuff into $arguments is important
+        $arguments = [$binary];
         foreach ($options as $key => $value) {
-            $builder->add("--$key");
+            $arguments[] = "--$key";
             if ($value !== null) {
-                $builder->add($value);
+                $arguments[] = $value;
             }
         }
 
-        $builder->add($this->fullyQualifiedClassName);
-        $builder->add($this->getPath());
+        $arguments[] = $this->fullyQualifiedClassName ?? '';
+        $arguments[] = $this->getPath();
 
-        $process = $builder->getProcess();
 
-        return $process->getCommandLine();
+        return (new Process($arguments))->getCommandLine();
     }
 
     /**

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -17,8 +17,12 @@ class PHPUnitTest extends FunctionalTestBase
         $proc = $this->invokeParatest('passing-tests', ['bootstrap' => $bootstrap]);
         $errors = $proc->getErrorOutput();
         $this->assertEquals(1, $proc->getExitCode(), 'Unexpected exit code');
-        $this->assertContains('[RuntimeException]', $errors, 'Expected exception name not found in output');
-        $this->assertContains(sprintf('Bootstrap specified but could not be found (%s)', $bootstrap), $errors, 'Expected error message not found in output');
+
+        // The [RuntimeException] message appears only on lower 6.x versions of Phpunit
+        $this->assertRegExp(
+            '/(\[RuntimeException\]|Bootstrap specified but could not be found)/',
+            $errors, 'Expected exception name not found in output'
+        );
     }
 
     public function testWithJustConfiguration()

--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -21,7 +21,8 @@ class PHPUnitTest extends FunctionalTestBase
         // The [RuntimeException] message appears only on lower 6.x versions of Phpunit
         $this->assertRegExp(
             '/(\[RuntimeException\]|Bootstrap specified but could not be found)/',
-            $errors, 'Expected exception name not found in output'
+            $errors,
+            'Expected exception name not found in output'
         );
     }
 

--- a/test/unit/Console/VersionProviderTest.php
+++ b/test/unit/Console/VersionProviderTest.php
@@ -32,7 +32,7 @@ class VersionProviderTest extends TestCase
         $this->assertInternalType('string', $actual, 'Version of phpunit package was found installed');
 
         // dev-master is included here as the phpunit package is checked and there is a dev-master used on travis
-        $this->assertRegExp("~^dev-master|\d.\d.\d+$~", $actual, 'Actual version number');
+        $this->assertRegExp("~^dev-master|\d.\d.(.)+$~", $actual, 'Actual version number');
 
         $actual = $provider->getComposerInstalledVersion('foooo/barazzoraz');
         $this->assertNull($actual, 'No version for non-existent package');


### PR DESCRIPTION
This PR makes paratest compatible with Symfony 4 components as well as allowing installation as a dependency alongside projects using said components.

Symfony Process: there's no easy way to compatibilize Symfony Process usage from 3.2 to 4.0 without a great deal of boilerplate. ProcessBuilder is deprecated in 3.4 and removed in 4, so Process has to be used directly. Unfortunately the method signature is different across Symfony 3 versions (3.2 requires a string as a first argument, 3.3/4 require an array).

As a tradeoff, this PR locks minimum version at 3.4 which happens to be LTS. 3.2 is currently unsupported.