### PR TITLE
Fixed problem composer installs with bin-compat full

### DIFF
--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -205,7 +205,7 @@ class Options
      */
     protected static function phpunit(): string
     {
-        $vendor  = static::vendorDir();
+        $vendor = static::vendorDir();
 
         $phpunit = $vendor . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'phpunit';
         $batch = $phpunit . '.bat';

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -212,7 +212,7 @@ class Options
 
         if (DIRECTORY_SEPARATOR === '\\' && file_exists($batch)) {
             return $phpunit . '.bat';
-        } elseif(file_exists($phpunit)) {
+        } elseif (file_exists($phpunit)) {
             return $phpunit;
         }
 

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -205,15 +205,14 @@ class Options
      */
     protected static function phpunit(): string
     {
-        $vendor = static::vendorDir();
+        $vendor  = static::vendorDir();
+
         $phpunit = $vendor . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'phpunit';
         $batch = $phpunit . '.bat';
 
-        if (file_exists($batch)) {
-            return $batch;
-        }
-
-        if (file_exists($phpunit)) {
+        if (DIRECTORY_SEPARATOR === '\\' && file_exists($batch)) {
+            return $phpunit . '.bat';
+        } elseif(file_exists($phpunit)) {
             return $phpunit;
         }
 


### PR DESCRIPTION
This will fix the method for determining the phpunit path, when installing e.g. on windows with the composer configuration "bin-compat": "full" and running tests inside a linux docker.  
The problem was that the current sollution determines the phpunit executable file based on the existence of the ".bat"-file. This solution will determine the executable based on file existence and the systems DIRECTORY_SEPERATOR.