### PR TITLE
Fix handling of special characters in JUnit XML

### DIFF
--- a/src/Logging/JUnit/Writer.php
+++ b/src/Logging/JUnit/Writer.php
@@ -164,7 +164,7 @@ class Writer
     protected function appendDefects(\DOMElement $caseNode, array $defects, string $type)
     {
         foreach ($defects as $defect) {
-            $defectNode = $this->document->createElement($type, htmlentities($defect['text']) . "\n");
+            $defectNode = $this->document->createElement($type, htmlspecialchars($defect['text'], ENT_XML1) . "\n");
             $defectNode->setAttribute('type', $defect['type']);
             $caseNode->appendChild($defectNode);
         }

--- a/test/fixtures/results/data-provider-with-special-chars.xml
+++ b/test/fixtures/results/data-provider-with-special-chars.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="UnitTestWithDataProviderSpecialCharsTest" tests="1" assertions="1" failures="1" errors="0" time="0.000898" file="/opt/projects/paratest/test/fixtures/failing-tests/UnitTestWithDataProviderSpecialCharsTest.php">
+    <testcase name="testIsItFalse with data set #0" class="UnitTestWithDataProviderSpecialCharsTest" file="/opt/projects/paratest/test/fixtures/failing-tests/UnitTestWithDataProviderSpecialCharsTest.php" line="13" assertions="1" time="0.000898">
+      <failure type="PHPUnit_Framework_ExpectationFailedException">UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #0 ('—')
+Failed asserting that '—' is false.
+
+/opt/projects/paratest/test/fixtures/failing-tests/UnitTestWithDataProviderSpecialCharsTest.php:13
+</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/test/unit/Logging/JUnit/WriterTest.php
+++ b/test/unit/Logging/JUnit/WriterTest.php
@@ -47,6 +47,16 @@ class WriterTest extends \TestBase
         $this->assertXmlStringEqualsXmlString(file_get_contents($mixed), $xml);
     }
 
+    public function testDataProviderWithSpecialCharacters()
+    {
+        $mixed = FIXTURES . DS . 'results' . DS . 'data-provider-with-special-chars.xml';
+        $reader = new Reader($mixed);
+        $this->interpreter->addReader($reader);
+        $writer = new Writer($this->interpreter, 'test/fixtures/tests/');
+        $xml = $writer->getXml();
+        $this->assertXmlStringEqualsXmlString(file_get_contents($mixed), $xml);
+    }
+
     public function testWrite()
     {
         $output = FIXTURES . DS . 'logs' . DS . 'passing.xml';


### PR DESCRIPTION
PR #127 started escaping all HTML entities in order to produce valid JUnit XML. However, this is problematic because characters like `—` (`&mdash;`) and `…` (`&hellip;`) get escaped and produce invalid XML due to the `&` character.

Switching to `htmlspecialchars` ensures that only intended characters are escaped.